### PR TITLE
Allow specification of test/dev users per development environment

### DIFF
--- a/config/dev_dummyauth/dev_users
+++ b/config/dev_dummyauth/dev_users
@@ -1,0 +1,3 @@
+testuser.project1
+testuser.project2
+otheruser.project1

--- a/jh_slurm_pod.yaml
+++ b/jh_slurm_pod.yaml
@@ -1,12 +1,4 @@
 apiVersion: core/v1
-kind: ConfigMap
-metadata:
-  name: dev-user-config
-data:
-  DEV_USER_CONFIG_UNIX_USERNAMES: "testuser.project1 testuser.project2 otheruser.project1"
-immutable: true
----
-apiVersion: core/v1
 kind: Pod
 metadata:
   name: jupyterhub-slurm

--- a/jh_slurm_pod.yaml
+++ b/jh_slurm_pod.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: dev-user-config
 data:
-  DEV_USER_CONFIG_DEFAULT_SHORT_NAME: "testuser"
   DEV_USER_CONFIG_UNIX_USERNAMES: "testuser.project1 testuser.project2 otheruser.project1"
 immutable: true
 ---


### PR DESCRIPTION
* `jh_slurm_pod.sh` dynamically creates a `ConfigMap` that contains a space-separated list of test user names of the form `<USER>.<PROJECT>`
* The list of test user names is extracted from a file: `config/<env_str>/dev_users`, where `<env_str>` is a string that identifies the environment, e.g. "dev_dummyauth"
* The list of user names is mapped to an environment variable `DEV_USER_CONFIG_UNIX_USERNAMES` in both the JupyterHub and Slurm containers
* The dev (mocked authentication) JupyterHub config  uses this environment variable to derive dummy `short_name` and `projects` claims for use in mocked JWT authentication when JupyterHub is launched. The `<USER>` component of the first username in the list is used as the `short_name` claim for the user who is automatically authenticated for the dev JupyterHub.
* On startup the Slurm container runs a script to create user accounts and home directories with Isambard-style paths (`/home/<PROJECT>/<USER>.<PROJECT>` using the information in the environment variable

These changes lay the groundwork to allow test user accounts to be specified for each dev environment (e.g. "dev_realauth"), potentially when launching the podman pod. This flexibility will be required for dev environments where real authentication takes place, to ensure that Slurm container contains the necessary user accounts for users that authenticate with JWTs.
