### PR TITLE
Dev environment that interacts with external Slurm + older podman/buildah compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,59 @@ openssl rand -base64 36
 
 This environment is intended to be used for testing non-authentication components, where user HTTP requests to the JupyterHub server do not include a valid JWT to authenticate to JupyterHub.
 
+##### `dev_dummyauth_extslurm`
+
+JupyterHub in a Podman pod interacting with an external Slurm instance over SSH with mocked JWT authentication
+
+* JupyterHub container initial volume data: [volumes/dev_dummyauth_extslurm/jupyterhub_root](./volumes/dev_dummyauth_extslurm/jupyterhub_root)
+* Pod configuration data: [config/dev_dummyauth_extslurm](./config/dev_dummyauth_extslurm)
+* Deployment scripts: [scripts/dev_dummyauth_extslurm](./scripts/dev_dummyauth_extslurm)
+
+Deploy `ConfigMap` example:
+
+```yaml
+apiVersion: core/v1
+kind: ConfigMap
+metadata:
+  name: deploy-config
+data:
+  dummyAuthPassword: "MyVerySecurePassword"
+  sshHostname: "ssh.example.local"
+  devUsers: "testuser.project1 testuser.project2 otheruser.project1"
+  slurmSpawnerWrappersBin: "/path/to/slurmspawner_wrappers/bin"
+  condaPrefixDir: "/path/to/conda"
+  jupyterDataDir: "/path/to/jupyter/data"
+  hubConnectUrl: "http://hub.example.local:8081"
+immutable: true
+```
+
+In this environment, JupyterHub is configured to use `DummyBricsAuthenticator` (defined in [the JupyterHub configuration file](./volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py)) which mocks the behaviour of `BricsAuthenticator` from [bricsauthenticator][bricsauthenticator-github], authenticating the first user in the from the value of `devUsers` in the deploy `ConfigMap` (`<USER>` part of `<USER>.<PROJECT>`).
+See [`dev_dummyauth`](#dev_dummyauth) for details on the format of `devUsers`.
+
+In order to spawning to work in the external Slurm instance, the `jupyterspawner` service user on the `sshHostname` should be able to switch users using `sudo -u <USER>.<PROJECT>` and run [`slurmspawner_wrappers`](slurmspawner_wrappers-github) scripts on behalf of the user to run jobs.
+See [`jupyterhub_config.py`](./volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py) for details of the commands run on the SSH server, and [`jupyterspawner_sudoers`](./brics_slurm/jupyterspawner_sudoers) for an example `sudoers` configuration fragment that grants these permissions in the [`brics_slurm` container](./brics_slurm/Containerfile).
+
+As in [`dev_dummyauth`](#dev_dummyauth), `DummyBricsAuthenticator` overrides JupyterHub's `DummyAuthenticator.authenticate()` and a password (`dummyAuthPassword`) must be provided to access JupyterHub as the user specified in `devUsers`
+See [`dev_dummyauth`](#dev_dummyauth) for information and recommendations on setting `dummyAuthPassword`.
+
+Other keys in the deploy `ConfigMap` configure how JupyterHub and spawned user instances interact with the external Slurm instance.
+In [`dev_dummyauth`](#dev_dummyauth) these values do not need to be specified as the
+
+* `sshHostname`: host name or IP address that JupyterHub should connect to over SSH to run Slurm commands (via [slurmspawner_wrapper](slurmspawner_wrappers-github))
+* `slurmSpawnerWrappersBin`: path to directory containing the `slurmspawner_{sbatch,scancel,squeue}` scripts on the SSH server (typically installed within a Python venv)
+* `condaPrefixDir`: path to the Conda prefix directory for the Conda installation where the Jupyter user environment is installed, e.g. [`jupyter-user-env.yaml`](./brics_slurm/jupyter-user-env.yaml) is installed), used by spawned user jobs to run `jupyterhub-singleuser`
+  * This is the value of the `CONDA_PREFIX` environment variable when the base environment is activated
+* `jupyterDataDir`: path to the Jupyter data directory to be used by spawner user servers, prepended to the [`JUPYTER_PATH` environment variable][jupyter-path-envvar-jupyter-docs] in spawned user jobs
+  * This can be used to provide [kernelspecs][kernelspecs-jupyter-client-docs] to all notebook users
+* `hubConnectUrl`: URL for user Jupyter servers to connect to the Hub API
+  * User servers (e.g. running on compute nodes) must be able to communicate over HTTP to this URL
+  * The host and port component of the URL should resolve to the IP and port on which port 8081 inside the JupyterHub container is published (see [Bring up a dev environment](#bring-up-a-dev-environment))
+
+This environment is intended to be used for testing non-authentication components, where user HTTP requests to the JupyterHub server do not include a valid JWT to authenticate to JupyterHub.
+
+[jupyter-path-envvar-jupyter-docs]: https://docs.jupyter.org/en/stable/use/jupyter-directories.html#envvar-JUPYTER_PATH
+[kernelspecs-jupyter-client-docs]: https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernel-specs
+
 ##### `dev_realauth`
 
 JupyterHub and Slurm containers in a Podman pod interacting over SSH with real JWT authentication

--- a/README.md
+++ b/README.md
@@ -328,8 +328,14 @@ bash build_env_resources.sh <env_name>
 bash build_env_manifest.sh <env_name> /path/to/deploy_dir
 
 # Bring up podman pod with per-deployment configuration
-podman kube play --configmap /path/to/deploy_dir/deploy-configmap.yaml /path/to/deploy_dir/combined.yaml
+podman kube play --configmap /path/to/deploy_dir/deploy-configmap.yaml [--publish ip:hostPort:containerPort] /path/to/deploy_dir/combined.yaml
 ```
+
+> ![NOTE]
+> The `--publish` option for `podman kube play` is only required for dev environments which spawn user sessions outside of the `podman` pod, e.g. [`dev_dummyauth_extslurm`](#dev_dummyauth_extslurm).
+> This is used to publish the Hub API to a host IP so that spawned user servers can communicate with JupyterHub.
+> The `ip` and `hostPort` should correspond to the host and port used in `hubConnectUrl` in the deploy `ConfigMap`.
+> The `containerPort` should be port the Hub API is listening on in the JupyterHub container (default `8081`).
 
 As described in [Available dev environments](#available-dev-environments), [`build_env_resources.sh`](./build_env_resources.sh) uses container definitions (in [`brics_jupyterhub`](./brics_jupyterhub/) and [`brics_slurm`](./brics_slurm/)) and data under [`volumes`](./volumes) to build resources required to bring up the `podman` pod (container images, volumes). Once these resources are built, [`build_env_manifest.sh`](./build_env_manifest.sh) constructs an environment-specific K8s manifest YAML describing the `Pod` dev environment. This combines dynamically generated YAML documents with a fixed per-environment YAML document under [`config`](./config). The combined YAML document can then used to start a `podman` pod using [`podman kube play`][podman-kube-play-podman-docs], with deployment-specific configuration provided by the deploy `ConfigMap`.
 

--- a/brics_jupyterhub/Containerfile
+++ b/brics_jupyterhub/Containerfile
@@ -32,9 +32,12 @@ COPY --chmod=0755 start-jupyterhub ${JUPYTERHUB_LAUNCHER}
 # Generate default configuration file and place in JupyterHub configuration directory
 RUN cd "${JUPYTERHUB_CONFIG_DIR}" && jupyterhub --generate-config
 
+# Add script to fix permissions and ownership on SSH key data mounted into container
+COPY --chmod=0700 fix_ssh_perms.sh /usr/local/sbin/fix_ssh_perms.sh
+
 WORKDIR ${JUPYTERHUB_SRV_DIR}
 
-CMD ["start-jupyterhub", "--debug"]
+CMD ["/bin/sh", "-c", "/usr/local/sbin/fix_ssh_perms.sh; start-jupyterhub --debug"]
 
 # BUILD DEV IMAGE
 # Modify the base image for development

--- a/brics_jupyterhub/Containerfile
+++ b/brics_jupyterhub/Containerfile
@@ -5,13 +5,11 @@ FROM quay.io/jupyterhub/jupyterhub:latest AS stage-base
 RUN rm -f /etc/localtime /etc/timezone
 
 # Install packages from distribution repos
-RUN <<EOF
-apt-get update && apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   openssh-client \
-  git
-apt-get clean
+  git && \
+apt-get clean && \
 rm -rf /var/lib/apt/lists/*
-EOF
 
 # Install packages using pip
 RUN python3 -m pip install --no-cache-dir --root-user-action=ignore \
@@ -29,30 +27,10 @@ JUPYTERHUB_LAUNCHER="/usr/local/bin/start-jupyterhub"
 RUN mkdir --verbose --parents "${JUPYTERHUB_CONFIG_DIR}" "${JUPYTERHUB_SRV_DIR}" "${JUPYTERHUB_LOG_DIR}"
 
 # Create JupyterHub launcher script: Owned by root, world-readable and executable
-# NOTE: Here doc delimiter is quoted ("EOF") to prevent parameter expansion when writing file
-RUN cat > "${JUPYTERHUB_LAUNCHER}" <<"EOF" && chmod --verbose u=rwx,g=rx,o=rx "${JUPYTERHUB_LAUNCHER}"
-#!/bin/bash
-cd "${JUPYTERHUB_SRV_DIR}"
-JUPYTERHUB_CONFIG_FILE="${JUPYTERHUB_CONFIG_DIR}/jupyterhub_config.py"
-JUPYTERHUB_LOG_FILE="${JUPYTERHUB_LOG_DIR}/jupyterhub_log_$(date +%Y%m%d-%H%M%S).log"
-JUPYTERHUB_CRYPT_KEY_FILE="${JUPYTERHUB_SRV_DIR}/jupyterhub_crypt_key"
-
-if [[ ! -f "$JUPYTERHUB_CRYPT_KEY_FILE" ]]; then
-  # Generate new encryption key and write to file
-  echo "Generating new JupyterHub crypt key..."
-  openssl rand -hex 32 > "$JUPYTERHUB_CRYPT_KEY_FILE"
-fi
-export JUPYTERHUB_CRYPT_KEY=$(<${JUPYTERHUB_CRYPT_KEY_FILE})
-
-set -x
-exec /usr/local/bin/jupyterhub -f "${JUPYTERHUB_CONFIG_FILE}" "$@" 2>&1 | tee "${JUPYTERHUB_LOG_FILE}"
-EOF
+COPY --chmod=0755 start-jupyterhub ${JUPYTERHUB_LAUNCHER}
 
 # Generate default configuration file and place in JupyterHub configuration directory
-RUN <<EOF
-cd "${JUPYTERHUB_CONFIG_DIR}"
-jupyterhub --generate-config
-EOF
+RUN cd "${JUPYTERHUB_CONFIG_DIR}" && jupyterhub --generate-config
 
 WORKDIR ${JUPYTERHUB_SRV_DIR}
 
@@ -72,11 +50,9 @@ RUN mkdir -p ${DEV_DATA_DIR}
 COPY _dev_build_data/bricsauthenticator ${DEV_DATA_DIR}/bricsauthenticator
 
 # Remove installed bricsauthenticator and replace with local version from host
-RUN <<EOF
-python3 -m pip uninstall --yes --root-user-action=ignore bricsauthenticator
+RUN python3 -m pip uninstall --yes --root-user-action=ignore bricsauthenticator && \
 python3 -m pip install --no-cache-dir --root-user-action=ignore --editable \
   "${DEV_DATA_DIR}/bricsauthenticator[dev]"
-EOF
 
 # BUILD PROD IMAGE
 # Modify the base image for production

--- a/brics_jupyterhub/fix_ssh_perms.sh
+++ b/brics_jupyterhub/fix_ssh_perms.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# TODO Remove permission fixes for SSH client keys when podman >= v4.8.0 can be assumed
+#   podman kube play for podman < v4.8.0 does not use defaultMode for volumes,
+#   so permissions must be be set at runtime
+# SSH client private keys from mounted volume
+chmod u=rw,g=,o= ${JUPYTERHUB_SRV_DIR}/ssh_key
+

--- a/brics_jupyterhub/start-jupyterhub
+++ b/brics_jupyterhub/start-jupyterhub
@@ -1,0 +1,15 @@
+#!/bin/bash
+cd "${JUPYTERHUB_SRV_DIR}"
+JUPYTERHUB_CONFIG_FILE="${JUPYTERHUB_CONFIG_DIR}/jupyterhub_config.py"
+JUPYTERHUB_LOG_FILE="${JUPYTERHUB_LOG_DIR}/jupyterhub_log_$(date +%Y%m%d-%H%M%S).log"
+JUPYTERHUB_CRYPT_KEY_FILE="${JUPYTERHUB_SRV_DIR}/jupyterhub_crypt_key"
+
+if [[ ! -f "$JUPYTERHUB_CRYPT_KEY_FILE" ]]; then
+  # Generate new encryption key and write to file
+  echo "Generating new JupyterHub crypt key..."
+  openssl rand -hex 32 > "$JUPYTERHUB_CRYPT_KEY_FILE"
+fi
+export JUPYTERHUB_CRYPT_KEY=$(<${JUPYTERHUB_CRYPT_KEY_FILE})
+
+set -x
+exec /usr/local/bin/jupyterhub -f "${JUPYTERHUB_CONFIG_FILE}" "$@" 2>&1 | tee "${JUPYTERHUB_LOG_FILE}"

--- a/brics_slurm/Containerfile
+++ b/brics_slurm/Containerfile
@@ -10,14 +10,12 @@ RUN rm -f /etc/localtime /etc/timezone
 # Also remove SSH host keys auto-generated during install. SSH host keys should 
 # be generated on container startup or mounted into the container to prevent
 # fixed keys from being baked into the container image.
-RUN <<EOF
-apt-get update && apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   openssh-server \
-  sudo
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+  sudo && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/* && \
 rm /etc/ssh/ssh_host_*
-EOF
 
 # Create directory for installing supporting tools and data for Jupyter
 ENV OPT_JUPYTER_DIR=/opt/jupyter
@@ -25,30 +23,22 @@ RUN mkdir -p ${OPT_JUPYTER_DIR}
 
 # Install slurmspawner_wrappers Python package in venv
 ENV SLURMSPAWNER_VENV_DIR=${OPT_JUPYTER_DIR}/slurmspawner_wrappers
-RUN <<EOF
-python3 -m venv --upgrade-deps ${SLURMSPAWNER_VENV_DIR}
+RUN python3 -m venv --upgrade-deps ${SLURMSPAWNER_VENV_DIR} && \
 ${SLURMSPAWNER_VENV_DIR}/bin/python -m pip install "slurmspawner_wrappers @ git+https://github.com/isambard-sc/slurmspawner_wrappers.git"
-EOF
 
 # Install Miniforge
 ENV MINIFORGE_PREFIX_DIR=${OPT_JUPYTER_DIR}/miniforge3
-RUN --mount=type=tmpfs,dst=/tmp/download <<EOF
-curl --fail --silent --show-error --location --output "/tmp/download/Miniforge3-latest.sh" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN --mount=type=tmpfs,dst=/tmp/download \
+curl --fail --silent --show-error --location --output "/tmp/download/Miniforge3-latest.sh" "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
 bash /tmp/download/Miniforge3-latest.sh -b -p ${MINIFORGE_PREFIX_DIR}
-EOF
 
 # Install Jupyter user environment
 COPY jupyter-user-env.yaml ${OPT_JUPYTER_DIR}/jupyter-user-env.yaml
-RUN <<EOF
-. ${OPT_JUPYTER_DIR}/miniforge3/bin/activate
+RUN . ${OPT_JUPYTER_DIR}/miniforge3/bin/activate && \
 conda env create --file="${OPT_JUPYTER_DIR}/jupyter-user-env.yaml"
-EOF
 
 # Update sshd config to prevent password auth and increase log verbosity
-RUN cat > /etc/ssh/sshd_config.d/custom.conf <<EOF
-PasswordAuthentication no
-LogLevel VERBOSE
-EOF
+COPY sshd_config_custom.conf /etc/ssh/sshd_config.d/custom.conf
 
 # Update SSHD_OPTS to set custom log output file for sshd service
 RUN sed -E -i -e 's#^SSHD_OPTS=$#&"-E /var/log/sshd.log"#' /etc/default/ssh
@@ -92,11 +82,9 @@ RUN mkdir -p ${DEV_DATA_DIR}
 COPY _dev_build_data/slurmspawner_wrappers ${DEV_DATA_DIR}/slurmspawner_wrappers
 
 # Remove installed bricsauthenticator and replace with local version from host
-RUN <<EOF
-${SLURMSPAWNER_VENV_DIR}/bin/python -m pip uninstall --yes --root-user-action=ignore slurmspawner_wrappers
+RUN ${SLURMSPAWNER_VENV_DIR}/bin/python -m pip uninstall --yes --root-user-action=ignore slurmspawner_wrappers && \
 ${SLURMSPAWNER_VENV_DIR}/bin/python -m pip install --no-cache-dir --root-user-action=ignore --editable \
   "${DEV_DATA_DIR}/slurmspawner_wrappers[dev]"
-EOF
 
 # Copy script for creating test users in dev environment
 COPY --chmod=0700 create_dev_users.sh /usr/local/sbin/create_dev_users.sh

--- a/brics_slurm/create_dev_users.sh
+++ b/brics_slurm/create_dev_users.sh
@@ -8,10 +8,10 @@
 # privileged account.
 #
 # Usernames of the form <USER>.<PROJECT> are extracted from the environment
-# variable DEV_USER_CONFIG_UNIX_USERNAMES.
+# variable DEPLOY_CONFIG_DEV_USERS.
 set -euo pipefail
 
-for UNIX_USERNAME in ${DEV_USER_CONFIG_UNIX_USERNAMES}; do
+for UNIX_USERNAME in ${DEPLOY_CONFIG_DEV_USERS}; do
   SHORT_NAME=${UNIX_USERNAME%.*}
   PROJECT=${UNIX_USERNAME##*.}
   echo "Creating test user ${UNIX_USERNAME}, with home /home/${PROJECT}/${UNIX_USERNAME}"

--- a/brics_slurm/fix_ssh_perms.sh
+++ b/brics_slurm/fix_ssh_perms.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-# Authorized keys for jupyterspawner user
+# Authorized keys for jupyterspawner user from mounted volume
 chown -R jupyterspawner:jupyterspawner /home/jupyterspawner/.ssh
+chmod u=rwx,g=,o= /home/jupyterspawner/.ssh
 chmod u=rw,g=,o= /home/jupyterspawner/.ssh/authorized_keys
+
+# TODO Remove permission fixes for SSH host keys when podman >= v4.8.0 can be assumed
+#   podman kube play for podman < v4.8.0 does not use defaultMode for volumes,
+#   so permissions must be be set at runtime
+# SSH host private keys from mounted volume
+chmod u=rw,g=,o= /etc/ssh/ssh_host_*_key

--- a/brics_slurm/sshd_config_custom.conf
+++ b/brics_slurm/sshd_config_custom.conf
@@ -1,0 +1,2 @@
+PasswordAuthentication no
+LogLevel VERBOSE

--- a/config/dev_dummyauth/dev_users
+++ b/config/dev_dummyauth/dev_users
@@ -1,3 +1,0 @@
-testuser.project1
-testuser.project2
-otheruser.project1

--- a/config/dev_dummyauth/pod.yaml
+++ b/config/dev_dummyauth/pod.yaml
@@ -6,9 +6,27 @@ spec:
   containers:
     - name: jupyterhub
       image: localhost/brics_jupyterhub:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
+      env:
+        - name: DEPLOY_CONFIG_DUMMYAUTH_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: dummyAuthPassword
+              optional: false
+        - name: DEPLOY_CONFIG_SSH_HOSTNAME
+          value: localhost
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
+        - name: DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN
+          value: /opt/jupyter/slurmspawner_wrappers/bin
+        - name: DEPLOY_CONFIG_CONDA_PREFIX_DIR
+          value: /opt/jupyter/miniforge3
+        - name: DEPLOY_CONFIG_JUPYTER_DATA_DIR
+          value: /opt/jupyter/jupyter_data
       ports:
         - containerPort: 8000
           hostIP: 127.0.0.1

--- a/config/dev_dummyauth/pod.yaml
+++ b/config/dev_dummyauth/pod.yaml
@@ -36,7 +36,11 @@ spec:
         # SSH client private key from Secret
         - name: ssh_client_key_vol
           mountPath: /srv/jupyterhub/ssh_key
-          readOnly: true
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
           subPath: ssh_key
 
         # SSH client public key from Secret
@@ -90,7 +94,11 @@ spec:
         # SSH host private key from Secret
         - name: ssh_host_key_vol
           mountPath: /etc/ssh/ssh_host_ed25519_key
-          readOnly: true
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
           subPath: ssh_key
 
         # SSH host public key from Secret

--- a/config/dev_dummyauth/pod.yaml
+++ b/config/dev_dummyauth/pod.yaml
@@ -75,9 +75,13 @@ spec:
 
     - name: slurm
       image: localhost/brics_slurm:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
+      env:
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
       volumeMounts:
         # sshd log file
         - name: slurm_root_vol

--- a/config/dev_dummyauth_extslurm/.gitignore
+++ b/config/dev_dummyauth_extslurm/.gitignore
@@ -1,0 +1,1 @@
+/dev_users

--- a/config/dev_dummyauth_extslurm/dev_users.example
+++ b/config/dev_dummyauth_extslurm/dev_users.example
@@ -1,0 +1,3 @@
+testuser.project1
+testuser.project2
+otheruser.project1

--- a/config/dev_dummyauth_extslurm/dev_users.example
+++ b/config/dev_dummyauth_extslurm/dev_users.example
@@ -1,3 +1,0 @@
-testuser.project1
-testuser.project2
-otheruser.project1

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -1,0 +1,78 @@
+apiVersion: core/v1
+kind: Pod
+metadata:
+  name: jupyterhub-slurm-dev_dummyauth_extslurm
+spec:
+  containers:
+    - name: jupyterhub
+      image: localhost/brics_jupyterhub:dev-latest
+      envFrom:
+        - configMapRef:
+            name: dev-user-config
+      env:
+        - valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: DEPLOY_CONFIG_SSH_HOSTNAME
+      ports:
+        - containerPort: 8000
+          hostIP: 127.0.0.1
+          hostPort: 8000
+          protocol: TCP
+      volumeMounts:
+        # JupyterHub configuration
+        - name: jupyterhub_root_vol
+          mountPath: /etc/jupyterhub
+          readOnly: true
+          subPath: /etc/jupyterhub
+
+        # JupyterHub server data
+        - name: jupyterhub_root_vol
+          mountPath: /srv/jupyterhub
+          readOnly: false
+          subPath: /srv/jupyterhub
+
+        # JupyterHub logs
+        - name: jupyterhub_root_vol
+          mountPath: /var/log/jupyterhub
+          readOnly: false
+          subPath: /var/log/jupyterhub
+
+        # SSH client private key from Secret
+        - name: ssh_client_key_vol
+          mountPath: /srv/jupyterhub/ssh_key
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
+          subPath: ssh_key
+
+        # SSH client public key from Secret
+        - name: ssh_client_key_vol
+          mountPath: /srv/jupyterhub/ssh_key.pub
+          readOnly: true
+          subPath: ssh_key.pub
+
+        # ssh_known_hosts file containing SSH host public key for Slurm container
+        - name: ssh_host_key_vol
+          mountPath: /etc/ssh/ssh_known_hosts
+          readOnly: true
+          subPath: localhost_known_hosts
+
+  volumes:
+    - name: jupyterhub_root_vol
+      persistentVolumeClaim:
+        claimName: jupyterhub_root_dev_dummyauth_extslurm
+        readOnly: false
+
+    - name: ssh_client_key_vol
+      secret:
+        secretName: jupyterhub-slurm-ssh-client-key-dev_dummyauth_extslurm
+        defaultMode: 0600
+
+    - name: ssh_host_key_vol
+      secret:
+        secretName: jupyterhub-slurm-ssh-host-key-dev_dummyauth_extslurm
+        defaultMode: 0600
+

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -10,6 +10,12 @@ spec:
         - configMapRef:
             name: dev-user-config
       env:
+        - name: DEPLOY_CONFIG_DUMMYAUTH_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: dummyAuthPassword
+              optional: false
         - name: DEPLOY_CONFIG_SSH_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -22,6 +22,12 @@ spec:
               name: deploy-config
               key: sshHostname
               optional: false
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
       ports:
         - containerPort: 8000
           hostIP: 127.0.0.1

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -25,6 +25,24 @@ spec:
               name: deploy-config
               key: devUsers
               optional: false
+        - name: DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: slurmSpawnerWrappersBin
+              optional: false
+        - name: DEPLOY_CONFIG_CONDA_PREFIX_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: condaPrefixDir
+              optional: false
+        - name: DEPLOY_CONFIG_JUPYTER_DATA_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: jupyterDataDir
+              optional: false
       ports:
         - containerPort: 8000
           hostIP: 127.0.0.1

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -66,10 +66,10 @@ spec:
           subPath: ssh_key.pub
 
         # ssh_known_hosts file containing SSH host public key for Slurm container
-        - name: ssh_host_key_vol
+        - name: ssh_known_hosts_vol
           mountPath: /etc/ssh/ssh_known_hosts
           readOnly: true
-          subPath: localhost_known_hosts
+          subPath: ssh_known_hosts
 
   volumes:
     - name: jupyterhub_root_vol
@@ -82,8 +82,8 @@ spec:
         secretName: jupyterhub-slurm-ssh-client-key-dev_dummyauth_extslurm
         defaultMode: 0600
 
-    - name: ssh_host_key_vol
+    - name: ssh_known_hosts_vol
       secret:
-        secretName: jupyterhub-slurm-ssh-host-key-dev_dummyauth_extslurm
-        defaultMode: 0600
+        secretName: jupyterhub-slurm-ssh-known-hosts-dev_dummyauth_extslurm
+        defaultMode: 0644
 

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -6,9 +6,6 @@ spec:
   containers:
     - name: jupyterhub
       image: localhost/brics_jupyterhub:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
       env:
         - name: DEPLOY_CONFIG_DUMMYAUTH_PASSWORD
           valueFrom:

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -10,10 +10,12 @@ spec:
         - configMapRef:
             name: dev-user-config
       env:
-        - valueFrom:
+        - name: DEPLOY_CONFIG_SSH_HOSTNAME
+          valueFrom:
             configMapKeyRef:
               name: deploy-config
-              key: DEPLOY_CONFIG_SSH_HOSTNAME
+              key: sshHostname
+              optional: false
       ports:
         - containerPort: 8000
           hostIP: 127.0.0.1

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -43,6 +43,12 @@ spec:
               name: deploy-config
               key: jupyterDataDir
               optional: false
+        - name: DEPLOY_CONFIG_HUB_CONNECT_URL
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: hubConnectUrl
+              optional: false
       ports:
         - containerPort: 8000
           hostIP: 127.0.0.1

--- a/config/dev_realauth/.gitignore
+++ b/config/dev_realauth/.gitignore
@@ -1,1 +1,0 @@
-/dev_users

--- a/config/dev_realauth/dev_users.example
+++ b/config/dev_realauth/dev_users.example
@@ -1,3 +1,0 @@
-testuser.project1
-testuser.project2
-otheruser.project1

--- a/config/dev_realauth/pod.yaml
+++ b/config/dev_realauth/pod.yaml
@@ -6,9 +6,21 @@ spec:
   containers:
     - name: jupyterhub
       image: localhost/brics_jupyterhub:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
+      env:
+        - name: DEPLOY_CONFIG_SSH_HOSTNAME
+          value: localhost
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
+        - name: DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN
+          value: /opt/jupyter/slurmspawner_wrappers/bin
+        - name: DEPLOY_CONFIG_CONDA_PREFIX_DIR
+          value: /opt/jupyter/miniforge3
+        - name: DEPLOY_CONFIG_JUPYTER_DATA_DIR
+          value: /opt/jupyter/jupyter_data
       ports:
         - containerPort: 8000
           hostIP: 127.0.0.1
@@ -36,7 +48,11 @@ spec:
         # SSH client private key from Secret
         - name: ssh_client_key_vol
           mountPath: /srv/jupyterhub/ssh_key
-          readOnly: true
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
           subPath: ssh_key
 
         # SSH client public key from Secret
@@ -53,9 +69,13 @@ spec:
 
     - name: slurm
       image: localhost/brics_slurm:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
+      env:
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
       volumeMounts:
         # sshd log file
         - name: slurm_root_vol
@@ -90,7 +110,11 @@ spec:
         # SSH host private key from Secret
         - name: ssh_host_key_vol
           mountPath: /etc/ssh/ssh_host_ed25519_key
-          readOnly: true
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
           subPath: ssh_key
 
         # SSH host public key from Secret
@@ -125,4 +149,4 @@ spec:
       secret:
         secretName: jupyterhub-slurm-ssh-host-key-dev_realauth
         defaultMode: 0600
- 
+

--- a/config/dev_realauth_zenithclient/.gitignore
+++ b/config/dev_realauth_zenithclient/.gitignore
@@ -1,1 +1,0 @@
-/dev_users

--- a/config/dev_realauth_zenithclient/dev_users.example
+++ b/config/dev_realauth_zenithclient/dev_users.example
@@ -1,3 +1,0 @@
-testuser.project1
-testuser.project2
-otheruser.project1

--- a/config/dev_realauth_zenithclient/pod.yaml
+++ b/config/dev_realauth_zenithclient/pod.yaml
@@ -6,9 +6,21 @@ spec:
   containers:
     - name: jupyterhub
       image: localhost/brics_jupyterhub:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
+      env:
+        - name: DEPLOY_CONFIG_SSH_HOSTNAME
+          value: localhost
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
+        - name: DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN
+          value: /opt/jupyter/slurmspawner_wrappers/bin
+        - name: DEPLOY_CONFIG_CONDA_PREFIX_DIR
+          value: /opt/jupyter/miniforge3
+        - name: DEPLOY_CONFIG_JUPYTER_DATA_DIR
+          value: /opt/jupyter/jupyter_data
       volumeMounts:
         # JupyterHub configuration
         - name: jupyterhub_root_vol
@@ -31,7 +43,11 @@ spec:
         # SSH client private key from Secret
         - name: ssh_client_key_vol
           mountPath: /srv/jupyterhub/ssh_key
-          readOnly: true
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
           subPath: ssh_key
 
         # SSH client public key from Secret
@@ -48,9 +64,13 @@ spec:
 
     - name: slurm
       image: localhost/brics_slurm:dev-latest
-      envFrom:
-        - configMapRef:
-            name: dev-user-config
+      env:
+        - name: DEPLOY_CONFIG_DEV_USERS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devUsers
+              optional: false
       volumeMounts:
         # sshd log file
         - name: slurm_root_vol
@@ -85,7 +105,11 @@ spec:
         # SSH host private key from Secret
         - name: ssh_host_key_vol
           mountPath: /etc/ssh/ssh_host_ed25519_key
-          readOnly: true
+          # TODO Switch to readOnly: true when podman >= v4.8.0 can be assumed
+          #   podman < v4.8.0 does not use defaultMode for volumes, so
+          #   permissions must be set at runtime
+          #readOnly: true
+          readOnly: false # necessary to set correct permissions at runtime
           subPath: ssh_key
 
         # SSH host public key from Secret

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -136,7 +136,7 @@ EOF
 #
 # A newline-separated list of user account names is read in from the file
 # provided as first argument and converted to a space-separated value for the
-# DEV_USER_CONFIG_UNIX_USERNAMES data key. It is expected that the key will be
+# DEPLOY_CONFIG_DEV_USERS data key. It is expected that the key will be
 # used to populate an environment variable within containers.
 #
 # Usage:
@@ -156,7 +156,7 @@ kind: ConfigMap
 metadata:
   name: dev-user-config
 data:
-  DEV_USER_CONFIG_UNIX_USERNAMES: "$(tr "\n" " " < "${1}" | sed -E -e 's/\s+$//')"
+  DEPLOY_CONFIG_DEV_USERS: "$(tr "\n" " " < "${1}" | sed -E -e 's/\s+$//')"
 immutable: true
 EOF
 }

--- a/scripts/dev_dummyauth/build_manifest.sh
+++ b/scripts/dev_dummyauth/build_manifest.sh
@@ -33,8 +33,6 @@ if [[ ! -d ${CONFIG_DIR} ]]; then
 fi
 
 cat > "${DEPLOY_DIR}/combined.yaml" <<EOF
-$(make_dev_user_configmap ${CONFIG_DIR}/dev_users)
----
 $(make_ssh_key_secret "${DEPLOY_DIR}/ssh_client_key" "JupyterHub-Slurm dev environment client key" "jupyterhub-slurm-ssh-client-key-${ENV_NAME}")
 ---
 $(make_ssh_key_secret "${DEPLOY_DIR}/ssh_host_ed25519_key" "JupyterHub-Slurm dev environment host key" "jupyterhub-slurm-ssh-host-key-${ENV_NAME}")

--- a/scripts/dev_dummyauth_extslurm/build_manifest.sh
+++ b/scripts/dev_dummyauth_extslurm/build_manifest.sh
@@ -35,7 +35,7 @@ fi
 cat > "${DEPLOY_DIR}/combined.yaml" <<EOF
 $(make_ssh_key_secret_from_files "${DEPLOY_DIR}/ssh_client_key" "jupyterhub-slurm-ssh-client-key-${ENV_NAME}")
 ---
-$(make_ssh_key_secret_from_files "${DEPLOY_DIR}/ssh_host_ed25519_key" "jupyterhub-slurm-ssh-host-key-${ENV_NAME}")
+$(make_secret_from_file "${DEPLOY_DIR}/ssh_known_hosts" "ssh_known_hosts" "jupyterhub-slurm-ssh-known-hosts-${ENV_NAME}")
 ---
 $(cat ${CONFIG_DIR}/pod.yaml)
 EOF

--- a/scripts/dev_dummyauth_extslurm/build_manifest.sh
+++ b/scripts/dev_dummyauth_extslurm/build_manifest.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck source=SCRIPTDIR/../common.sh
+. scripts/common.sh
+
+ENV_NAME="dev_dummyauth_extslurm"
+
+USAGE="
+  ./build_manifest.sh <deploy_dir>
+"
+
+# Validate number of arguments
+if (( $# != 1 )); then
+  echoerr "Error: incorrect number of arguments ($#)"
+  echoerr
+  echoerr "Usage: ${USAGE}"
+  exit 1
+fi 
+
+# Directory in which to place K8s manifest YAML and supporting data
+DEPLOY_DIR=${1}
+if [[ ! -d ${DEPLOY_DIR} ]]; then
+  echoerr "Error: ${DEPLOY_DIR} is not a directory"
+  exit 1
+fi
+
+# Environment-specific directory containing additional configuration data
+CONFIG_DIR="config/${ENV_NAME}"
+if [[ ! -d ${CONFIG_DIR} ]]; then
+  echoerr "Error: ${CONFIG_DIR} is not a directory"
+  exit 1
+fi
+
+cat > "${DEPLOY_DIR}/combined.yaml" <<EOF
+$(make_dev_user_configmap ${DEPLOY_DIR}/dev_users)
+---
+$(make_ssh_key_secret_from_files "${DEPLOY_DIR}/ssh_client_key" "jupyterhub-slurm-ssh-client-key-${ENV_NAME}")
+---
+$(make_ssh_key_secret_from_files "${DEPLOY_DIR}/ssh_host_ed25519_key" "jupyterhub-slurm-ssh-host-key-${ENV_NAME}")
+---
+$(cat ${CONFIG_DIR}/pod.yaml)
+EOF

--- a/scripts/dev_dummyauth_extslurm/build_manifest.sh
+++ b/scripts/dev_dummyauth_extslurm/build_manifest.sh
@@ -33,8 +33,6 @@ if [[ ! -d ${CONFIG_DIR} ]]; then
 fi
 
 cat > "${DEPLOY_DIR}/combined.yaml" <<EOF
-$(make_dev_user_configmap ${DEPLOY_DIR}/dev_users)
----
 $(make_ssh_key_secret_from_files "${DEPLOY_DIR}/ssh_client_key" "jupyterhub-slurm-ssh-client-key-${ENV_NAME}")
 ---
 $(make_ssh_key_secret_from_files "${DEPLOY_DIR}/ssh_host_ed25519_key" "jupyterhub-slurm-ssh-host-key-${ENV_NAME}")

--- a/scripts/dev_dummyauth_extslurm/build_resources.sh
+++ b/scripts/dev_dummyauth_extslurm/build_resources.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck source=SCRIPTDIR/../common.sh
+. scripts/common.sh
+
+ENV_NAME="dev_dummyauth_extslurm"
+CONTAINER_BUILD_STAGE="stage-dev"
+
+USAGE="
+  ./build_resources.sh
+"
+
+# Validate number of arguments
+if (( $# != 0 )); then
+  echoerr "Error: incorrect number of arguments ($#)"
+  echoerr
+  echoerr "Usage: ${USAGE}"
+  exit 1
+fi 
+
+# Get user and group for JupyterHub container volume from environment, or set defaults
+: "${JUPYTERUSER:=root}"
+: "${JUPYTERUSER_UID:=0}"
+: "${JUPYTERGROUP:=root}"
+: "${JUPYTERGROUP_GID:=0}"
+
+# Environment-specific directory containing initial volume contents
+VOLUME_DIR="volumes/${ENV_NAME}"
+if [[ ! -d ${VOLUME_DIR} ]]; then
+  echoerr "Error: ${VOLUME_DIR} is not a directory"
+  exit 1
+fi
+
+# If not already present, clone repositories to be mounted into dev images
+clone_repo_skip_existing https://github.com/isambard-sc/bricsauthenticator.git brics_jupyterhub/_dev_build_data/bricsauthenticator
+
+# Build local container images
+podman build -t brics_jupyterhub:dev-latest --target=${CONTAINER_BUILD_STAGE} ./brics_jupyterhub
+
+# Create podman named volume containing JupyterHub data
+create_podman_volume_from_dir jupyterhub_root_${ENV_NAME} "${JUPYTERUSER}:${JUPYTERUSER_UID}" "${JUPYTERGROUP}:${JUPYTERGROUP_GID}"  "${VOLUME_DIR}/jupyterhub_root/"

--- a/scripts/dev_realauth/build_manifest.sh
+++ b/scripts/dev_realauth/build_manifest.sh
@@ -33,8 +33,6 @@ if [[ ! -d ${CONFIG_DIR} ]]; then
 fi
 
 cat > "${DEPLOY_DIR}/combined.yaml" <<EOF
-$(make_dev_user_configmap ${CONFIG_DIR}/dev_users)
----
 $(make_ssh_key_secret "${DEPLOY_DIR}/ssh_client_key" "JupyterHub-Slurm dev environment client key" "jupyterhub-slurm-ssh-client-key-${ENV_NAME}")
 ---
 $(make_ssh_key_secret "${DEPLOY_DIR}/ssh_host_ed25519_key" "JupyterHub-Slurm dev environment host key" "jupyterhub-slurm-ssh-host-key-${ENV_NAME}")

--- a/scripts/dev_realauth_zenithclient/build_manifest.sh
+++ b/scripts/dev_realauth_zenithclient/build_manifest.sh
@@ -33,8 +33,6 @@ if [[ ! -d ${CONFIG_DIR} ]]; then
 fi
 
 cat > "${DEPLOY_DIR}/combined.yaml" <<EOF
-$(make_dev_user_configmap ${CONFIG_DIR}/dev_users)
----
 $(make_ssh_key_secret "${DEPLOY_DIR}/ssh_client_key" "JupyterHub-Slurm dev environment client key" "jupyterhub-slurm-ssh-client-key-${ENV_NAME}")
 ---
 $(make_ssh_key_secret "${DEPLOY_DIR}/ssh_host_ed25519_key" "JupyterHub-Slurm dev environment host key" "jupyterhub-slurm-ssh-host-key-${ENV_NAME}")

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -7,8 +7,15 @@ c = get_config()  #noqa
 from pathlib import Path
 
 import batchspawner  # Even though not used, needed to register batchspawner interface
-from bricsauthenticator import BricsAuthenticator
-from jupyterhub.handlers import BaseHandler
+from jupyterhub.auth import DummyAuthenticator
+
+def get_env_var_value(var_name: str) -> str:
+    
+    from os import environ
+    try:
+        return environ[var_name]
+    except KeyError as e:
+        raise RuntimeError(f"Environment variable {var_name} must be set") from e
 
 # The JupyterHub public proxy should listen on all interfaces, with a base URL
 # of /jupyter
@@ -38,19 +45,14 @@ def get_short_name_claim_list() -> list[str]:
     Return a list of strings that look like decoded short_name claims
 
     Gets a whitespace-separated list of Unix usernames in the form
-    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment or
-    raises RuntimeError.
+    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment.
 
     Constructs the list of short_name claims as by extracting unique <USER>
     values from the list of Unix usernames. The returned list retains the order
     in which the usernames first appear in DEPLOY_CONFIG_DEV_USERS.
     """
     from collections import OrderedDict
-    from os import environ
-    try:
-        unix_usernames = environ["DEPLOY_CONFIG_DEV_USERS"]
-    except KeyError as e:
-        raise RuntimeError("Environment variable DEPLOY_CONFIG_DEV_USERS must be set") from e
+    unix_usernames = get_env_var_value("DEPLOY_CONFIG_DEV_USERS")
 
     # Use OrderedDict keys as an ordered set-like object
     return list(OrderedDict.fromkeys([unix_username.split(".")[0] for unix_username in unix_usernames.split()]))
@@ -68,20 +70,15 @@ def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict
     Return a dict that looks like a decoded projects claim for `username`
 
     Gets a whitespace-separated list of Unix usernames in the form
-    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment or
-    raises RuntimeError.
+    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment.
 
     Constructs the projects claim as a dictionary mapping all <PROJECT> values
     with corresponding <USER> == `username` to a default list of infrastructures.
     """
-    from os import environ
     if infrastructures is None:
         infrastructures = ["slurm.aip1.isambard", "jupyter.aip1.isambard", "slurm.3.isambard"]
 
-    try:
-        unix_usernames = environ["DEPLOY_CONFIG_DEV_USERS"]
-    except KeyError as e:
-        raise RuntimeError("Environment variable DEPLOY_CONFIG_DEV_USERS must be set") from e
+    unix_usernames = get_env_var_value("DEPLOY_CONFIG_DEV_USERS")
 
     projects = [unix_username.split(".")[1] for unix_username in unix_usernames.split() if unix_username.split(".")[0] == username]
 
@@ -89,26 +86,25 @@ def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict
 
 DUMMY_AUTH_STATE = get_projects_claim(DUMMY_USERNAME)
 
-class DummyBricsLoginHandler(BaseHandler):
+class DummyBricsAuthenticator(DummyAuthenticator):
     """
-    Handler with dummy get() that authenticates with a fixed username and auth_state
-    """
-    async def get(self):
-        user = await self.auth_to_user({"name": DUMMY_USERNAME, "auth_state": DUMMY_AUTH_STATE})
-        self.set_login_cookie(user)
-        next_url = self.get_next_url(user)
-        self.redirect(next_url)
+    Authenticator that presents a login page, but authenticates user in with fixed credentials
 
-class DummyBricsAuthenticator(BricsAuthenticator):
-    """
-    Replaces login page handler for BricsAuthenticator with a handler with dummy get method
+    A fixed username and auth_state are returned by `authenticate()` which do not depend on the
+    username and password provided in the login form POST data. If the `password` traitlet is set
+    then authentication to the fixed credentials will only be possible if a matching password is
+    provided in the login form. The username submitted in the form is not used.
     
-    This can be used in place of BricsAuthenticator when testing BricsSlurmSpawner
-    (which expects auth_state) in a context where HTTP requests do not contain
-    valid JWTs
+    This can be used in place of BricsAuthenticator when testing BricsSlurmSpawner (which expects
+    auth_state) in a context where HTTP requests do not contain valid JWTs.
     """
-    def get_handlers(self, app):
-        return [(r"/login", DummyBricsLoginHandler)]
+    async def authenticate(self, handler, data):
+       # Delegate password authentication to parent class method.
+       # If successful, authenticate user using fixed dummy username and
+       # auth_state.
+       if await super().authenticate(handler, data) is not None:
+           return {"name": DUMMY_USERNAME, "auth_state": DUMMY_AUTH_STATE}
+       return None
 
 # Use BriCS-customised Authenticator class (registered as entry point by
 # bricsauthenticator package)
@@ -144,8 +140,8 @@ c.Spawner.env_keep = []
 # with JUPYTERHUB_* to ensure that they are passed through the `sudo` command
 # used to invoke `sbatch` (according to the sudoers policy)
 c.Spawner.environment = {
-    "JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR": "/opt/jupyter/miniforge3",
-    "JUPYTERHUB_BRICS_OPT_JUPYTER_DIR": "/opt/jupyter"
+    "JUPYTERHUB_BRICS_CONDA_PREFIX_DIR": get_env_var_value("DEPLOY_CONFIG_CONDA_PREFIX_DIR"),
+    "JUPYTERHUB_BRICS_JUPYTER_DATA_DIR": get_env_var_value("DEPLOY_CONFIG_JUPYTER_DATA_DIR")
 }
 
 # Default notebook directory is the user's home directory (`~` is expanded)
@@ -161,18 +157,12 @@ def get_ssh_key_file() -> Path:
     Gets JUPYTERHUB_SRV_DIR from environment or raises RuntimeError.
     Also raises RuntimeError if $JUPYTERHUB_SRV_DIR/ssh_key does not exist.
     """
-    from os import environ
-    try:
-        srv_dir = environ["JUPYTERHUB_SRV_DIR"]
-    except KeyError as e:
-        raise RuntimeError("Environment variable JUPYTERHUB_SRV_DIR must be set") from e
+    srv_dir = get_env_var_value("JUPYTERHUB_SRV_DIR")
 
     try:
         return (Path(srv_dir) / "ssh_key").resolve(strict=True)
     except FileNotFoundError as e:
         raise RuntimeError(f"SSH private key not found at expected location") from e
-
-
 
 # srun command used to run single-user server inside batch script
 # Modified to propagate all environment variables from batch script environment.
@@ -198,7 +188,7 @@ c.BricsSlurmSpawner.req_srun = "srun --export=ALL"
 # commands on the remote host over SSH by adding `ssh <hostname>` to the exec_prefix.
 SSH_CMD=["ssh",
     "-i", str(get_ssh_key_file()),
-    "jupyterspawner@localhost sudo -u {username}",
+    f"jupyterspawner@{get_env_var_value('DEPLOY_CONFIG_SSH_HOSTNAME')}", "sudo -u {username}",
 ]
 c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 
@@ -237,7 +227,7 @@ c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 # considered a single argument but might be split by the shell should be
 # double-quoted, so that only the outer quotes are removed when the
 # `ssh ... <cmd>` is processed by the shell.
-SLURMSPAWNER_WRAPPERS_BIN="/opt/jupyter/slurmspawner_wrappers/bin"
+SLURMSPAWNER_WRAPPERS_BIN = get_env_var_value("DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN")
 c.BricsSlurmSpawner.batch_submit_cmd = " ".join(
     [
         "{% for var in keepvars.split(',') %}{{var}}=\"'${{'{'}}{{var}}{{'}'}}'\" {% endfor %}",
@@ -281,9 +271,9 @@ c.BricsSlurmSpawner.batch_script = """#!/bin/bash
 
 set -euo pipefail
 
-source ${JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR}/bin/activate jupyter-user-env
+source ${JUPYTERHUB_BRICS_CONDA_PREFIX_DIR}/bin/activate jupyter-user-env
 
-export JUPYTER_PATH=${JUPYTERHUB_BRICS_OPT_JUPYTER_DIR}/jupyter_data${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
+export JUPYTER_PATH=${JUPYTERHUB_BRICS_JUPYTER_DATA_DIR}${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
 
 trap 'echo SIGTERM received' TERM
 {{prologue}}
@@ -299,3 +289,9 @@ echo "jupyterhub-singleuser ended gracefully"
 # `Spawner.auth_state_hook`. This is used to pass the value of the projects 
 # claim from the JWT received by Authenticator to the Spawner.
 c.Authenticator.enable_auth_state = True
+
+# Set a password for the dummy authenticator from the value of an environment
+# variable
+# To generate a random 48 char base64 password with openssl:
+#   openssl rand -base64 36
+c.Authenticator.password = get_env_var_value("DEPLOY_CONFIG_DUMMYAUTH_PASSWORD")

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -113,11 +113,6 @@ class DummyBricsAuthenticator(DummyAuthenticator):
 # Use DummyAuthenticator extended to provide mock auth_state to BricsSlurmSpawner
 c.JupyterHub.authenticator_class = DummyBricsAuthenticator
 
-# TODO Restrict allowed usernames to a list of dummy users, e.g. using 
-#   allowed_users configuration attribute. Then the product of the allowed users
-#   and projects in DUMMY_AUTH_STATE can be used to create project-specific test
-#   accounts in the Slurm container
-
 # Don't shut down single-user servers when Hub is shut down. This allows the hub
 # to restart and reconnect to running user servers
 c.JupyterHub.cleanup_servers = False

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -29,7 +29,7 @@ c.JupyterHub.hub_bind_url = "http://127.0.0.1:8081"
 # DUMMY_USERNAME is a fixed username which looks like a decoded short_name claim
 # that can be passed to the Spawner class as auth_state to mock the behaviour of
 # BricsAuthenticator without receiving a JWT. This is obtained from the
-# environment variable DEV_USER_CONFIG_UNIX_USERNAMES which should contain
+# environment variable DEPLOY_CONFIG_DEV_USERS which should contain
 # a space-separated list of usernames of the form `<USER>.<PROJECT>`. The
 # DUMMY_USERNAME is the `<USER>` part of the first `<USER>.<PROJECT>` name in
 # in the list.
@@ -38,19 +38,19 @@ def get_short_name_claim_list() -> list[str]:
     Return a list of strings that look like decoded short_name claims
 
     Gets a whitespace-separated list of Unix usernames in the form
-    <USER>.<PROJECT> from DEV_USER_CONFIG_UNIX_USERNAMES in the environment or
+    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment or
     raises RuntimeError.
 
     Constructs the list of short_name claims as by extracting unique <USER>
     values from the list of Unix usernames. The returned list retains the order
-    in which the usernames first appear in DEV_USER_CONFIG_UNIX_USERNAMES.
+    in which the usernames first appear in DEPLOY_CONFIG_DEV_USERS.
     """
     from collections import OrderedDict
     from os import environ
     try:
-        unix_usernames = environ["DEV_USER_CONFIG_UNIX_USERNAMES"]
+        unix_usernames = environ["DEPLOY_CONFIG_DEV_USERS"]
     except KeyError as e:
-        raise RuntimeError("Environment variable DEV_USER_CONFIG_UNIX_USERNAMES must be set") from e
+        raise RuntimeError("Environment variable DEPLOY_CONFIG_DEV_USERS must be set") from e
 
     # Use OrderedDict keys as an ordered set-like object
     return list(OrderedDict.fromkeys([unix_username.split(".")[0] for unix_username in unix_usernames.split()]))
@@ -61,14 +61,14 @@ DUMMY_USERNAME = short_name_claims[0]
 # DUMMY_AUTH_STATE is a fixed dictionary which looks like a decoded project claim
 # that can be passed to the Spawner class as auth_state to mock the behaviour of
 # BricsAuthenticator without receiving a JWT. This is generated using the list of
-# Unix usernames in the environment variable DEV_USER_CONFIG_UNIX_USERNAMES in
+# Unix usernames in the environment variable DEPLOY_CONFIG_DEV_USERS in
 # the environment of the JupyterHub process
 def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict[str, list[str]]:
     """
     Return a dict that looks like a decoded projects claim for `username`
 
     Gets a whitespace-separated list of Unix usernames in the form
-    <USER>.<PROJECT> from DEV_USER_CONFIG_UNIX_USERNAMES in the environment or
+    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment or
     raises RuntimeError.
 
     Constructs the projects claim as a dictionary mapping all <PROJECT> values
@@ -79,9 +79,9 @@ def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict
         infrastructures = ["slurm.aip1.isambard", "jupyter.aip1.isambard", "slurm.3.isambard"]
 
     try:
-        unix_usernames = environ["DEV_USER_CONFIG_UNIX_USERNAMES"]
+        unix_usernames = environ["DEPLOY_CONFIG_DEV_USERS"]
     except KeyError as e:
-        raise RuntimeError("Environment variable DEV_USER_CONFIG_UNIX_USERNAMES must be set") from e
+        raise RuntimeError("Environment variable DEPLOY_CONFIG_DEV_USERS must be set") from e
 
     projects = [unix_username.split(".")[1] for unix_username in unix_usernames.split() if unix_username.split(".")[0] == username]
 

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -173,6 +173,18 @@ def get_ssh_key_file() -> Path:
         raise RuntimeError(f"SSH private key not found at expected location") from e
 
 
+def get_ssh_hostname() -> str:
+    """
+    Return the hostname to be used for SSH connections
+
+    Gets DEPLOY_CONFIG_SSH_HOSTNAME from the environment or raises RuntimeError.
+    """
+    from os import environ
+    try:
+        return environ["DEPLOY_CONFIG_SSH_HOSTNAME"]
+    except KeyError as e:
+        raise RuntimeError("Environment variable DEPLOY_CONFIG_SSH_HOSTNAME must be set") from e
+
 
 # srun command used to run single-user server inside batch script
 # Modified to propagate all environment variables from batch script environment.
@@ -198,7 +210,7 @@ c.BricsSlurmSpawner.req_srun = "srun --export=ALL"
 # commands on the remote host over SSH by adding `ssh <hostname>` to the exec_prefix.
 SSH_CMD=["ssh",
     "-i", str(get_ssh_key_file()),
-    "jupyterspawner@localhost sudo -u {username}",
+    f"jupyterspawner@{get_ssh_hostname()}" + "sudo -u {username}",
 ]
 c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -210,7 +210,7 @@ c.BricsSlurmSpawner.req_srun = "srun --export=ALL"
 # commands on the remote host over SSH by adding `ssh <hostname>` to the exec_prefix.
 SSH_CMD=["ssh",
     "-i", str(get_ssh_key_file()),
-    f"jupyterspawner@{get_ssh_hostname()}" + "sudo -u {username}",
+    f"jupyterspawner@{get_ssh_hostname()}", "sudo -u {username}",
 ]
 c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -36,7 +36,7 @@ c.JupyterHub.hub_bind_url = "http://:8081"
 # DUMMY_USERNAME is a fixed username which looks like a decoded short_name claim
 # that can be passed to the Spawner class as auth_state to mock the behaviour of
 # BricsAuthenticator without receiving a JWT. This is obtained from the
-# environment variable DEV_USER_CONFIG_UNIX_USERNAMES which should contain
+# environment variable DEPLOY_CONFIG_DEV_USERS which should contain
 # a space-separated list of usernames of the form `<USER>.<PROJECT>`. The
 # DUMMY_USERNAME is the `<USER>` part of the first `<USER>.<PROJECT>` name in
 # in the list.
@@ -45,14 +45,14 @@ def get_short_name_claim_list() -> list[str]:
     Return a list of strings that look like decoded short_name claims
 
     Gets a whitespace-separated list of Unix usernames in the form
-    <USER>.<PROJECT> from DEV_USER_CONFIG_UNIX_USERNAMES in the environment.
+    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment.
 
     Constructs the list of short_name claims as by extracting unique <USER>
     values from the list of Unix usernames. The returned list retains the order
-    in which the usernames first appear in DEV_USER_CONFIG_UNIX_USERNAMES.
+    in which the usernames first appear in DEPLOY_CONFIG_DEV_USERS.
     """
     from collections import OrderedDict
-    unix_usernames = get_env_var_value("DEV_USER_CONFIG_UNIX_USERNAMES")
+    unix_usernames = get_env_var_value("DEPLOY_CONFIG_DEV_USERS")
 
     # Use OrderedDict keys as an ordered set-like object
     return list(OrderedDict.fromkeys([unix_username.split(".")[0] for unix_username in unix_usernames.split()]))
@@ -63,14 +63,14 @@ DUMMY_USERNAME = short_name_claims[0]
 # DUMMY_AUTH_STATE is a fixed dictionary which looks like a decoded project claim
 # that can be passed to the Spawner class as auth_state to mock the behaviour of
 # BricsAuthenticator without receiving a JWT. This is generated using the list of
-# Unix usernames in the environment variable DEV_USER_CONFIG_UNIX_USERNAMES in
+# Unix usernames in the environment variable DEPLOY_CONFIG_DEV_USERS in
 # the environment of the JupyterHub process
 def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict[str, list[str]]:
     """
     Return a dict that looks like a decoded projects claim for `username`
 
     Gets a whitespace-separated list of Unix usernames in the form
-    <USER>.<PROJECT> from DEV_USER_CONFIG_UNIX_USERNAMES in the environment.
+    <USER>.<PROJECT> from DEPLOY_CONFIG_DEV_USERS in the environment.
 
     Constructs the projects claim as a dictionary mapping all <PROJECT> values
     with corresponding <USER> == `username` to a default list of infrastructures.
@@ -78,7 +78,7 @@ def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict
     if infrastructures is None:
         infrastructures = ["slurm.aip1.isambard", "jupyter.aip1.isambard", "slurm.3.isambard"]
 
-    unix_usernames = get_env_var_value("DEV_USER_CONFIG_UNIX_USERNAMES")
+    unix_usernames = get_env_var_value("DEPLOY_CONFIG_DEV_USERS")
 
     projects = [unix_username.split(".")[1] for unix_username in unix_usernames.split() if unix_username.split(".")[0] == username]
 

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -25,6 +25,7 @@ c.JupyterHub.bind_url = "http://:8000/jupyter"
 # host IP address that can be reached by spawned single-user servers
 c.JupyterHub.hub_bind_url = "http://:8081"
 
+
 # BricsAuthenticator decodes claims from the JWT received in HTTP headers,
 # uses the short_name claim from the received JWT as the username of the
 # authenticated user, and passes the projects claim from the received JWT
@@ -132,6 +133,13 @@ c.JupyterHub.cleanup_servers = False
 # Use BriCS-customised SlurmSpawner class
 c.JupyterHub.spawner_class = "brics"
 
+# Since the Hub API is listening on all interfaces, spawners will by default use
+# the hostname of the JupyterHub container to connect to Hub API, which will not
+# be reachable from spawned user session in external Slurm instance. Set the
+# hub_connect_url to the IP and port on which the Hub API is published on the
+# container's host to ensure spawned user sessions can talk to the Hub API.
+c.Spawner.hub_connect_url = get_env_var_value('DEPLOY_CONFIG_HUB_CONNECT_URL')
+
 # The default env_keep contains a number of variables which do not need to be
 # passed from JupyterHub to the single-user server when starting the server as
 # a batch job.
@@ -147,8 +155,8 @@ c.Spawner.env_keep = []
 # with JUPYTERHUB_* to ensure that they are passed through the `sudo` command
 # used to invoke `sbatch` (according to the sudoers policy)
 c.Spawner.environment = {
-    "JUPYTERHUB_BRICS_CONDA_PREFIX_DIR": get_env_var_value["DEPLOY_CONFIG_CONDA_PREFIX_DIR"]
-    "JUPYTERHUB_BRICS_JUPYTER_DATA_DIR": get_env_var_value["DEPLOY_CONFIG_JUPYTER_DATA_DIR"]
+    "JUPYTERHUB_BRICS_CONDA_PREFIX_DIR": get_env_var_value("DEPLOY_CONFIG_CONDA_PREFIX_DIR"),
+    "JUPYTERHUB_BRICS_JUPYTER_DATA_DIR": get_env_var_value("DEPLOY_CONFIG_JUPYTER_DATA_DIR")
 }
 
 # Default notebook directory is the user's home directory (`~` is expanded)
@@ -234,7 +242,7 @@ c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 # considered a single argument but might be split by the shell should be
 # double-quoted, so that only the outer quotes are removed when the
 # `ssh ... <cmd>` is processed by the shell.
-SLURMSPAWNER_WRAPPERS_BIN = get_env_var_value["DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN"]
+SLURMSPAWNER_WRAPPERS_BIN = get_env_var_value("DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN")
 c.BricsSlurmSpawner.batch_submit_cmd = " ".join(
     [
         "{% for var in keepvars.split(',') %}{{var}}=\"'${{'{'}}{{var}}{{'}'}}'\" {% endfor %}",

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -147,8 +147,8 @@ c.Spawner.env_keep = []
 # with JUPYTERHUB_* to ensure that they are passed through the `sudo` command
 # used to invoke `sbatch` (according to the sudoers policy)
 c.Spawner.environment = {
-    "JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR": "/opt/jupyter/miniforge3",
-    "JUPYTERHUB_BRICS_OPT_JUPYTER_DIR": "/opt/jupyter"
+    "JUPYTERHUB_BRICS_CONDA_PREFIX_DIR": get_env_var_value["DEPLOY_CONFIG_CONDA_PREFIX_DIR"]
+    "JUPYTERHUB_BRICS_JUPYTER_DATA_DIR": get_env_var_value["DEPLOY_CONFIG_JUPYTER_DATA_DIR"]
 }
 
 # Default notebook directory is the user's home directory (`~` is expanded)
@@ -234,7 +234,7 @@ c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 # considered a single argument but might be split by the shell should be
 # double-quoted, so that only the outer quotes are removed when the
 # `ssh ... <cmd>` is processed by the shell.
-SLURMSPAWNER_WRAPPERS_BIN="/opt/jupyter/slurmspawner_wrappers/bin"
+SLURMSPAWNER_WRAPPERS_BIN = get_env_var_value["DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN"]
 c.BricsSlurmSpawner.batch_submit_cmd = " ".join(
     [
         "{% for var in keepvars.split(',') %}{{var}}=\"'${{'{'}}{{var}}{{'}'}}'\" {% endfor %}",
@@ -278,9 +278,9 @@ c.BricsSlurmSpawner.batch_script = """#!/bin/bash
 
 set -euo pipefail
 
-source ${JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR}/bin/activate jupyter-user-env
+source ${JUPYTERHUB_BRICS_CONDA_PREFIX_DIR}/bin/activate jupyter-user-env
 
-export JUPYTER_PATH=${JUPYTERHUB_BRICS_OPT_JUPYTER_DIR}/jupyter_data${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
+export JUPYTER_PATH=${JUPYTERHUB_BRICS_JUPYTER_DATA_DIR}${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
 
 trap 'echo SIGTERM received' TERM
 {{prologue}}

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -1,0 +1,301 @@
+"""
+JupyterHub configuration for deployment of containerised JupyterHub with BricsAuthenticator
+"""
+
+c = get_config()  #noqa
+
+from pathlib import Path
+
+import batchspawner  # Even though not used, needed to register batchspawner interface
+from bricsauthenticator import BricsAuthenticator
+from jupyterhub.handlers import BaseHandler
+
+# The JupyterHub public proxy should listen on all interfaces, with a base URL
+# of /jupyter
+c.JupyterHub.bind_url = "http://:8000/jupyter"
+
+# The Hub API should listen on all interfaces. The port will be published to a
+# host IP address that can be reached by spawned single-user servers
+c.JupyterHub.hub_bind_url = "http://:8081"
+
+# BricsAuthenticator decodes claims from the JWT received in HTTP headers,
+# uses the short_name claim from the received JWT as the username of the
+# authenticated user, and passes the projects claim from the received JWT
+# to BricsSpawner via auth_state. See
+#
+# * https://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html#authentication-state
+# * https://github.com/isambard-sc/bricsauthenticator/blob/main/src/bricsauthenticator/bricsauthenticator.py
+
+# DUMMY_USERNAME is a fixed username which looks like a decoded short_name claim
+# that can be passed to the Spawner class as auth_state to mock the behaviour of
+# BricsAuthenticator without receiving a JWT. This is obtained from the
+# environment variable DEV_USER_CONFIG_UNIX_USERNAMES which should contain
+# a space-separated list of usernames of the form `<USER>.<PROJECT>`. The
+# DUMMY_USERNAME is the `<USER>` part of the first `<USER>.<PROJECT>` name in
+# in the list.
+def get_short_name_claim_list() -> list[str]:
+    """
+    Return a list of strings that look like decoded short_name claims
+
+    Gets a whitespace-separated list of Unix usernames in the form
+    <USER>.<PROJECT> from DEV_USER_CONFIG_UNIX_USERNAMES in the environment or
+    raises RuntimeError.
+
+    Constructs the list of short_name claims as by extracting unique <USER>
+    values from the list of Unix usernames. The returned list retains the order
+    in which the usernames first appear in DEV_USER_CONFIG_UNIX_USERNAMES.
+    """
+    from collections import OrderedDict
+    from os import environ
+    try:
+        unix_usernames = environ["DEV_USER_CONFIG_UNIX_USERNAMES"]
+    except KeyError as e:
+        raise RuntimeError("Environment variable DEV_USER_CONFIG_UNIX_USERNAMES must be set") from e
+
+    # Use OrderedDict keys as an ordered set-like object
+    return list(OrderedDict.fromkeys([unix_username.split(".")[0] for unix_username in unix_usernames.split()]))
+
+short_name_claims = get_short_name_claim_list()
+DUMMY_USERNAME = short_name_claims[0]
+
+# DUMMY_AUTH_STATE is a fixed dictionary which looks like a decoded project claim
+# that can be passed to the Spawner class as auth_state to mock the behaviour of
+# BricsAuthenticator without receiving a JWT. This is generated using the list of
+# Unix usernames in the environment variable DEV_USER_CONFIG_UNIX_USERNAMES in
+# the environment of the JupyterHub process
+def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict[str, list[str]]:
+    """
+    Return a dict that looks like a decoded projects claim for `username`
+
+    Gets a whitespace-separated list of Unix usernames in the form
+    <USER>.<PROJECT> from DEV_USER_CONFIG_UNIX_USERNAMES in the environment or
+    raises RuntimeError.
+
+    Constructs the projects claim as a dictionary mapping all <PROJECT> values
+    with corresponding <USER> == `username` to a default list of infrastructures.
+    """
+    from os import environ
+    if infrastructures is None:
+        infrastructures = ["slurm.aip1.isambard", "jupyter.aip1.isambard", "slurm.3.isambard"]
+
+    try:
+        unix_usernames = environ["DEV_USER_CONFIG_UNIX_USERNAMES"]
+    except KeyError as e:
+        raise RuntimeError("Environment variable DEV_USER_CONFIG_UNIX_USERNAMES must be set") from e
+
+    projects = [unix_username.split(".")[1] for unix_username in unix_usernames.split() if unix_username.split(".")[0] == username]
+
+    return {project: infrastructures for project in projects}
+
+DUMMY_AUTH_STATE = get_projects_claim(DUMMY_USERNAME)
+
+class DummyBricsLoginHandler(BaseHandler):
+    """
+    Handler with dummy get() that authenticates with a fixed username and auth_state
+    """
+    async def get(self):
+        user = await self.auth_to_user({"name": DUMMY_USERNAME, "auth_state": DUMMY_AUTH_STATE})
+        self.set_login_cookie(user)
+        next_url = self.get_next_url(user)
+        self.redirect(next_url)
+
+class DummyBricsAuthenticator(BricsAuthenticator):
+    """
+    Replaces login page handler for BricsAuthenticator with a handler with dummy get method
+    
+    This can be used in place of BricsAuthenticator when testing BricsSlurmSpawner
+    (which expects auth_state) in a context where HTTP requests do not contain
+    valid JWTs
+    """
+    def get_handlers(self, app):
+        return [(r"/login", DummyBricsLoginHandler)]
+
+# Use BriCS-customised Authenticator class (registered as entry point by
+# bricsauthenticator package)
+#c.JupyterHub.authenticator_class = "brics"
+
+# Use DummyAuthenticator extended to provide mock auth_state to BricsSlurmSpawner
+c.JupyterHub.authenticator_class = DummyBricsAuthenticator
+
+# TODO Restrict allowed usernames to a list of dummy users, e.g. using 
+#   allowed_users configuration attribute. Then the product of the allowed users
+#   and projects in DUMMY_AUTH_STATE can be used to create project-specific test
+#   accounts in the Slurm container
+
+# Don't shut down single-user servers when Hub is shut down. This allows the hub
+# to restart and reconnect to running user servers
+c.JupyterHub.cleanup_servers = False
+
+# Use BriCS-customised SlurmSpawner class
+c.JupyterHub.spawner_class = "brics"
+
+# The default env_keep contains a number of variables which do not need to be
+# passed from JupyterHub to the single-user server when starting the server as
+# a batch job.
+# 
+# Set env_keep to empty list to avoid these environment variables from becoming
+# part of SlurmSpawner's keepvars template variable and their values in the
+# environment for JupyterHub being passed through to the spawned single-user
+# server.
+c.Spawner.env_keep = []
+
+# Set environment variables to pass information through to the job submission
+# script environment/spawned Jupyter user server. The variables are prefixed
+# with JUPYTERHUB_* to ensure that they are passed through the `sudo` command
+# used to invoke `sbatch` (according to the sudoers policy)
+c.Spawner.environment = {
+    "JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR": "/opt/jupyter/miniforge3",
+    "JUPYTERHUB_BRICS_OPT_JUPYTER_DIR": "/opt/jupyter"
+}
+
+# Default notebook directory is the user's home directory (`~` is expanded)
+c.Spawner.notebook_dir = '~/'
+
+# Allow up to 7 mins (420s) for user session to queue and start
+c.Spawner.start_timeout = 420
+
+def get_ssh_key_file() -> Path:
+    """
+    Return a path to an SSH key under JUPYTERHUB_SRV_DIR
+
+    Gets JUPYTERHUB_SRV_DIR from environment or raises RuntimeError.
+    Also raises RuntimeError if $JUPYTERHUB_SRV_DIR/ssh_key does not exist.
+    """
+    from os import environ
+    try:
+        srv_dir = environ["JUPYTERHUB_SRV_DIR"]
+    except KeyError as e:
+        raise RuntimeError("Environment variable JUPYTERHUB_SRV_DIR must be set") from e
+
+    try:
+        return (Path(srv_dir) / "ssh_key").resolve(strict=True)
+    except FileNotFoundError as e:
+        raise RuntimeError(f"SSH private key not found at expected location") from e
+
+
+
+# srun command used to run single-user server inside batch script
+# Modified to propagate all environment variables from batch script environment.
+# This is necessary because by default `srun` will only use environment variables
+# specified via the `sbatch` `--export` flag (via SLURM_EXPORT_ENV environment
+# variable). We use `--export` to only specify environment variables in
+# the keepvars template variable, which has been configured to exclude some
+# host-specific variables which are usually included by default, such as PATH.
+# This is because the values of these variables comes from the environment
+# JupyterHub is running, where PATH etc. is likely to differ to the PATH in a
+# batch script executing on a compute node. Using --export=ALL ensures that all
+# variables passed through from JupyterHub's environment via keepvars and any
+# other environment variables set by Slurm in the batch script environment are
+# propagated through `srun`.
+c.BricsSlurmSpawner.req_srun = "srun --export=ALL"
+
+# Prefix for commands used to interact with workload scheduler. Default is
+# "sudo -E -u {username}" from BatchSpawnerBase, which runs the command as the
+# user logged into JupyterHub. For single user testing we do not have `sudo`
+# and want to submit the job as the user who started JupyterHub.
+# When running JupyterHub in a context where we want to execute workload scheduler
+# commands on a different machine (e.g. from within a container), we can run scheduler
+# commands on the remote host over SSH by adding `ssh <hostname>` to the exec_prefix.
+SSH_CMD=["ssh",
+    "-i", str(get_ssh_key_file()),
+    "jupyterspawner@localhost sudo -u {username}",
+]
+c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
+
+# Batch submission command which explicitly sets environment for sbatch, passing 
+# as options to `sudo` from `exec_prefix`
+#
+# Explicitly setting the environment for the `batch_submit_cmd` is needed
+# because `ssh` does not by default allow passing of arbitrary environment
+# variables through to the remote process. OpenSSH client/server can be
+# configured allow specific whitelisted variables to be passed from `ssh`'s
+# environment into the environment of the remote process, but does not
+# do this by default.
+#
+# The exec_prefix and batch_submit_cmd attributes undergo template expansion
+# in BatchSpawner, so we can use Jinja2 templating features to insert
+# all environment variables. After template rendering, the full command
+# exec_prefix + batch_submit_cmd is run in a shell with environment specified
+# by the result of the Spawner class's get_env() function.
+#
+# `batch_submit_cmd` needs to submit the job using `sbatch`, passing the
+# environment variables in template variable keepvars through from the
+# environment of the `batch_submit_cmd` to the single-user
+# Jupyter server running in the Slurm job. As `sbatch` is being run via `ssh`,
+# it does not share the same environment as the `ssh` process (specified by
+# get_env()). In this case we expand the environment variables in `keepvars`
+# in the environment of the `ssh` process and then explicitly set their values
+# as arguments for an `env`/`sudo` command to setup the appropriate environment
+# for `sbatch` to pass through to the Slurm job.
+#
+# NOTE: Care must be taken with quoting! The exec_prefix + batch_submit_cmd is
+# run in a shell. Since the command run by the shell is `ssh ... <cmd>`, parameter
+# expansion and quote removal occur in the context the `ssh` command is run, not
+# in the context where the `<cmd>` is run. This is particularly important as
+# some of the `JUPYTERHUB_*` environment variables in keepvars contain quotes
+# themselves! In general, any portion of the command run by SSH that should be
+# considered a single argument but might be split by the shell should be
+# double-quoted, so that only the outer quotes are removed when the
+# `ssh ... <cmd>` is processed by the shell.
+SLURMSPAWNER_WRAPPERS_BIN="/opt/jupyter/slurmspawner_wrappers/bin"
+c.BricsSlurmSpawner.batch_submit_cmd = " ".join(
+    [
+        "{% for var in keepvars.split(',') %}{{var}}=\"'${{'{'}}{{var}}{{'}'}}'\" {% endfor %}",
+        f"{SLURMSPAWNER_WRAPPERS_BIN}/slurmspawner_sbatch",
+]
+)
+
+# For `batch_query_cmd` and `batch_cancel_cmd`, passing through environment
+# variables in `keepvars` is not necessary. However, we must still set the
+# environment to pass the required SLURMSPAWNER_JOB_ID environment variable to
+# the `slurmspawner_{scancel,squeue}` wrapper scripts, since these receive
+# parameters via environment variables (not command line arguments).
+c.BricsSlurmSpawner.batch_query_cmd = "SLURMSPAWNER_JOB_ID={{job_id}} " + f"{SLURMSPAWNER_WRAPPERS_BIN}/slurmspawner_squeue"
+c.BricsSlurmSpawner.batch_cancel_cmd = "SLURMSPAWNER_JOB_ID={{job_id}} " + f"{SLURMSPAWNER_WRAPPERS_BIN}/slurmspawner_scancel"
+
+# On Isambard-AI, no need to specify memory per node when --gpus is used to
+# request a number of GH200s because memory is allocated based on the number of
+# GPUs requested
+# `--mem=0` requests all memory on each requested compute node in `sbatch`, `srun`
+#c.BricsSlurmSpawner.req_memory = "0"
+# No need to specify number of nodes required, as Slurm should request the correct number
+# of nodes based on the number of GH200s requested
+# Request a single node for Jupyter session
+#c.BricsSlurmSpawner.req_options = "--nodes=1"
+# Based on default for SlurmSpawner
+# https://github.com/jupyterhub/batchspawner/blob/fe5a893eaf9eb5e121cbe36bad2e69af798e6140/batchspawner/batchspawner.py#L675
+c.BricsSlurmSpawner.batch_script = """#!/bin/bash
+#SBATCH --output={{homedir}}/jupyterhub_slurmspawner_%j.log
+#SBATCH --job-name=spawner-jupyterhub
+#SBATCH --chdir={{homedir}}
+#SBATCH --export={{keepvars}}
+#SBATCH --get-user-env=L
+{% if partition  %}#SBATCH --partition={{partition}}
+{% endif %}{% if runtime    %}#SBATCH --time={{runtime}}
+{% endif %}{% if memory     %}#SBATCH --mem={{memory}}
+{% endif %}{% if gres       %}#SBATCH --gres={{gres}}
+{% endif %}{% if ngpus      %}##SBATCH --gpus={{ngpus}}  # NOTE: --gpus disabled in Slurm dev environment
+{% endif %}{% if nprocs     %}#SBATCH --cpus-per-task={{nprocs}}
+{% endif %}{% if reservation%}#SBATCH --reservation={{reservation}}
+{% endif %}{% if options    %}#SBATCH {{options}}{% endif %}
+
+set -euo pipefail
+
+source ${JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR}/bin/activate jupyter-user-env
+
+export JUPYTER_PATH=${JUPYTERHUB_BRICS_OPT_JUPYTER_DIR}/jupyter_data${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
+
+trap 'echo SIGTERM received' TERM
+{{prologue}}
+{% if srun %}{{srun}} {% endif %}{{cmd}}
+echo "jupyterhub-singleuser ended gracefully"
+{{epilogue}}
+"""
+
+# Enable persisting of auth_state, which is used to persist authentication
+# information in JupyterHub's database. This is encrypted and the 
+# JUPYTERHUB_CRYPT_KEY environment variable must be set. `auth_state` is passed
+# from  `Authenticator.authenticate()` to the `Spawner` via 
+# `Spawner.auth_state_hook`. This is used to pass the value of the projects 
+# claim from the JWT received by Authenticator to the Spawner.
+c.Authenticator.enable_auth_state = True

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -87,13 +87,6 @@ def get_projects_claim(username: str, infrastructures: list[str] = None) -> dict
 
 DUMMY_AUTH_STATE = get_projects_claim(DUMMY_USERNAME)
 
-#    This can be used in place of BricsAuthenticator when testing BricsSlurmSpawner
-#    (which expects auth_state) in a context where HTTP requests do not contain
-#    valid JWTs
-#    """
-#    def get_handlers(self, app):
-#        return [(r"/login", DummyBricsLoginHandler)]
-
 class DummyBricsAuthenticator(DummyAuthenticator):
     """
     Authenticator that presents a login page, but authenticates user in with fixed credentials

--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -8,6 +8,14 @@ from pathlib import Path
 
 import batchspawner  # Even though not used, needed to register batchspawner interface
 
+def get_env_var_value(var_name: str) -> str:
+    
+    from os import environ
+    try:
+        return environ[var_name]
+    except KeyError as e:
+        raise RuntimeError(f"Environment variable {var_name} must be set") from e
+
 # The JupyterHub public proxy should listen on all interfaces, with a base URL
 # of /jupyter
 c.JupyterHub.bind_url = "http://:8000/jupyter"
@@ -50,8 +58,8 @@ c.Spawner.env_keep = []
 # with JUPYTERHUB_* to ensure that they are passed through the `sudo` command
 # used to invoke `sbatch` (according to the sudoers policy)
 c.Spawner.environment = {
-    "JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR": "/opt/jupyter/miniforge3",
-    "JUPYTERHUB_BRICS_OPT_JUPYTER_DIR": "/opt/jupyter"
+    "JUPYTERHUB_BRICS_CONDA_PREFIX_DIR": get_env_var_value("DEPLOY_CONFIG_CONDA_PREFIX_DIR"),
+    "JUPYTERHUB_BRICS_JUPYTER_DATA_DIR": get_env_var_value("DEPLOY_CONFIG_JUPYTER_DATA_DIR")
 }
 
 # Default notebook directory is the user's home directory (`~` is expanded)
@@ -67,18 +75,12 @@ def get_ssh_key_file() -> Path:
     Gets JUPYTERHUB_SRV_DIR from environment or raises RuntimeError.
     Also raises RuntimeError if $JUPYTERHUB_SRV_DIR/ssh_key does not exist.
     """
-    from os import environ
-    try:
-        srv_dir = environ["JUPYTERHUB_SRV_DIR"]
-    except KeyError as e:
-        raise RuntimeError("Environment variable JUPYTERHUB_SRV_DIR must be set") from e
+    srv_dir = get_env_var_value("JUPYTERHUB_SRV_DIR")
 
     try:
         return (Path(srv_dir) / "ssh_key").resolve(strict=True)
     except FileNotFoundError as e:
         raise RuntimeError(f"SSH private key not found at expected location") from e
-
-
 
 # srun command used to run single-user server inside batch script
 # Modified to propagate all environment variables from batch script environment.
@@ -104,7 +106,7 @@ c.BricsSlurmSpawner.req_srun = "srun --export=ALL"
 # commands on the remote host over SSH by adding `ssh <hostname>` to the exec_prefix.
 SSH_CMD=["ssh",
     "-i", str(get_ssh_key_file()),
-    "jupyterspawner@localhost sudo -u {username}",
+    f"jupyterspawner@{get_env_var_value('DEPLOY_CONFIG_SSH_HOSTNAME')}", "sudo -u {username}",
 ]
 c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 
@@ -143,7 +145,7 @@ c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 # considered a single argument but might be split by the shell should be
 # double-quoted, so that only the outer quotes are removed when the
 # `ssh ... <cmd>` is processed by the shell.
-SLURMSPAWNER_WRAPPERS_BIN="/opt/jupyter/slurmspawner_wrappers/bin"
+SLURMSPAWNER_WRAPPERS_BIN = get_env_var_value("DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN")
 c.BricsSlurmSpawner.batch_submit_cmd = " ".join(
     [
         "{% for var in keepvars.split(',') %}{{var}}=\"'${{'{'}}{{var}}{{'}'}}'\" {% endfor %}",
@@ -187,9 +189,9 @@ c.BricsSlurmSpawner.batch_script = """#!/bin/bash
 
 set -euo pipefail
 
-source ${JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR}/bin/activate jupyter-user-env
+source ${JUPYTERHUB_BRICS_CONDA_PREFIX_DIR}/bin/activate jupyter-user-env
 
-export JUPYTER_PATH=${JUPYTERHUB_BRICS_OPT_JUPYTER_DIR}/jupyter_data${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
+export JUPYTER_PATH=${JUPYTERHUB_BRICS_JUPYTER_DATA_DIR}${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
 
 trap 'echo SIGTERM received' TERM
 {{prologue}}

--- a/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -8,8 +8,16 @@ from pathlib import Path
 
 import batchspawner  # Even though not used, needed to register batchspawner interface
 
+def get_env_var_value(var_name: str) -> str:
+    
+    from os import environ
+    try:
+        return environ[var_name]
+    except KeyError as e:
+        raise RuntimeError(f"Environment variable {var_name} must be set") from e
+
 # The JupyterHub public proxy should listen on localhost, with a base URL
-# of /jupyter
+# of /jupyter. The Zenith client will proxy user traffic to localhost 
 c.JupyterHub.bind_url = "http://127.0.0.1:8000/jupyter"
 
 # The Hub API should listen on an IP address that can be reached by spawned
@@ -50,8 +58,8 @@ c.Spawner.env_keep = []
 # with JUPYTERHUB_* to ensure that they are passed through the `sudo` command
 # used to invoke `sbatch` (according to the sudoers policy)
 c.Spawner.environment = {
-    "JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR": "/opt/jupyter/miniforge3",
-    "JUPYTERHUB_BRICS_OPT_JUPYTER_DIR": "/opt/jupyter"
+    "JUPYTERHUB_BRICS_CONDA_PREFIX_DIR": get_env_var_value("DEPLOY_CONFIG_CONDA_PREFIX_DIR"),
+    "JUPYTERHUB_BRICS_JUPYTER_DATA_DIR": get_env_var_value("DEPLOY_CONFIG_JUPYTER_DATA_DIR")
 }
 
 # Default notebook directory is the user's home directory (`~` is expanded)
@@ -67,18 +75,12 @@ def get_ssh_key_file() -> Path:
     Gets JUPYTERHUB_SRV_DIR from environment or raises RuntimeError.
     Also raises RuntimeError if $JUPYTERHUB_SRV_DIR/ssh_key does not exist.
     """
-    from os import environ
-    try:
-        srv_dir = environ["JUPYTERHUB_SRV_DIR"]
-    except KeyError as e:
-        raise RuntimeError("Environment variable JUPYTERHUB_SRV_DIR must be set") from e
+    srv_dir = get_env_var_value("JUPYTERHUB_SRV_DIR")
 
     try:
         return (Path(srv_dir) / "ssh_key").resolve(strict=True)
     except FileNotFoundError as e:
         raise RuntimeError(f"SSH private key not found at expected location") from e
-
-
 
 # srun command used to run single-user server inside batch script
 # Modified to propagate all environment variables from batch script environment.
@@ -104,7 +106,7 @@ c.BricsSlurmSpawner.req_srun = "srun --export=ALL"
 # commands on the remote host over SSH by adding `ssh <hostname>` to the exec_prefix.
 SSH_CMD=["ssh",
     "-i", str(get_ssh_key_file()),
-    "jupyterspawner@localhost sudo -u {username}",
+    f"jupyterspawner@{get_env_var_value('DEPLOY_CONFIG_SSH_HOSTNAME')}", "sudo -u {username}",
 ]
 c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 
@@ -143,7 +145,7 @@ c.BricsSlurmSpawner.exec_prefix = " ".join(SSH_CMD)
 # considered a single argument but might be split by the shell should be
 # double-quoted, so that only the outer quotes are removed when the
 # `ssh ... <cmd>` is processed by the shell.
-SLURMSPAWNER_WRAPPERS_BIN="/opt/jupyter/slurmspawner_wrappers/bin"
+SLURMSPAWNER_WRAPPERS_BIN = get_env_var_value("DEPLOY_CONFIG_SLURMSPAWNER_WRAPPERS_BIN")
 c.BricsSlurmSpawner.batch_submit_cmd = " ".join(
     [
         "{% for var in keepvars.split(',') %}{{var}}=\"'${{'{'}}{{var}}{{'}'}}'\" {% endfor %}",
@@ -187,9 +189,9 @@ c.BricsSlurmSpawner.batch_script = """#!/bin/bash
 
 set -euo pipefail
 
-source ${JUPYTERHUB_BRICS_MINIFORGE_PREFIX_DIR}/bin/activate jupyter-user-env
+source ${JUPYTERHUB_BRICS_CONDA_PREFIX_DIR}/bin/activate jupyter-user-env
 
-export JUPYTER_PATH=${JUPYTERHUB_BRICS_OPT_JUPYTER_DIR}/jupyter_data${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
+export JUPYTER_PATH=${JUPYTERHUB_BRICS_JUPYTER_DATA_DIR}${JUPYTER_PATH:+:}${JUPYTER_PATH:-}
 
 trap 'echo SIGTERM received' TERM
 {{prologue}}


### PR DESCRIPTION
Changes to make existing environments compatible with the older version of `podman` and `buildah` on Isambard-AI

* Remove heredocs from `Containerfile`s
  * [Introduced in buildah 1.33.0](https://buildah.io/releases/2023/11/17/Buildah-version-v1.33.0.html)

* Set mounted `Secret` permissions at runtime
  * In older version of podman, `podman kube play` does not support the `defaultMode` setting for projected volumes in `Pod`s, so to workaround this a short script is run as part of the container `CMD` to fix permissions for projected volumes
  * [Introduced in podman 4.8.0](https://github.com/containers/podman/releases/tag/v4.8.0)

Added new environment: `dev_dummyauth_extslurm`

* JupyterHub in a Podman pod interacting with an external Slurm instance over SSH with mocked JWT authentication
* Mocked authentication with new `DummyBricsAuthenticator` that subclasses `DummyAuthenticator` (enables a password to be used to gate mocked authentication)
* Deployment-specific configuration injected using a separate `ConfigMap` YAML ("deploy `ConfigMap`") that is passed to `podman kube play` using the `--configmap` option

All other dev environments have been updated to be consistent with `dev_dummyauth_extslurm` 

* Integrate the changes for compatibility with older `podman` and `buildah` versions
* Use deploy `ConfigMap` to inject deployment-specific variables
* `dev_dummyauth` uses updated `DummyBricsAuthenticator`
 