### PR TITLE
Set values for new `BricsAuthenticator` v0.7.0 configurable attributes

### DIFF
--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -214,3 +214,10 @@ c.BricsAuthenticator.oidc_server = "https://keycloak-dev.isambard.ac.uk/realms/i
 # the token projects claim will be authenticated. Authenticated users can only spawn to projects
 # associated with this platform name.
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
+
+# Set audience for JWT. Only users presenting tokens with this as value for the "aud" claim will be
+# authenticated.
+c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
+
+# Set leeway (in seconds) for validating time-based claims in the JWT.
+c.BricsAuthenticator.jwt_leeway = 5

--- a/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -214,3 +214,10 @@ c.BricsAuthenticator.oidc_server = "https://keycloak-dev.isambard.ac.uk/realms/i
 # the token projects claim will be authenticated. Authenticated users can only spawn to projects
 # associated with this platform name.
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
+
+# Set audience for JWT. Only users presenting tokens with this as value for the "aud" claim will be
+# authenticated.
+c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
+
+# Set leeway (in seconds) for validating time-based claims in the JWT.
+c.BricsAuthenticator.jwt_leeway = 5

--- a/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -222,3 +222,10 @@ c.BricsAuthenticator.oidc_server = "https://keycloak.isambard.ac.uk/realms/isamb
 # the token projects claim will be authenticated. Authenticated users can only spawn to projects
 # associated with this platform name.
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
+
+# Set audience for JWT. Only users presenting tokens with this as value for the "aud" claim will be
+# authenticated.
+c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
+
+# Set leeway (in seconds) for validating time-based claims in the JWT.
+c.BricsAuthenticator.jwt_leeway = 5


### PR DESCRIPTION
Set `BricsAuthenticator.jwt_{audience,leeway}` in config files for environments with real authentication