### PR TITLE
Shorten JupyterHub login cookie lifetime to 12h

### DIFF
--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -317,12 +317,6 @@ c.Authenticator.allowed_users = {DUMMY_USERNAME}
 # associated with this platform name.
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
 
-# Set 12 h Max-Age for cookies set by JupyterHub (43200 = 60 * 60 * 12 seconds)
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#max-agenumber
-# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.set_cookie
-# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L651
-#c.JupyterHub.tornado_settings = {"cookie_options": {"max_age": 43200 }}
-
 # Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
 # cookie itself
 # https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
@@ -330,6 +324,6 @@ c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
 # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
 #c.JupyterHub.cookie_max_age_days = 0.5
 
-# DEBUG: 60s cookie_max_age_days, 10s HubAuth.cache_max_age 10s
-c.JupyterHub.cookie_max_age_days = 60 / 86400
+# DEBUG: 300s cookie_max_age_days, 10s HubAuth.cache_max_age 10s
+c.JupyterHub.cookie_max_age_days = 300 / 86400
 c.BricsSlurmSpawner.args= ['--HubAuth.cache_max_age=10']

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -316,3 +316,16 @@ c.Authenticator.allowed_users = {DUMMY_USERNAME}
 # the token projects claim will be authenticated. Authenticated users can only spawn to projects
 # associated with this platform name.
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
+
+# Set 12 h Max-Age for cookies set by JupyterHub (43200 = 60 * 60 * 12 seconds)
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#max-agenumber
+# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.set_cookie
+# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L651
+#c.JupyterHub.tornado_settings = {"cookie_options": {"max_age": 43200 }}
+
+# Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
+# cookie itself
+# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
+# https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
+# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
+c.JupyterHub.cookie_max_age_days = 0.5

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -328,4 +328,8 @@ c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
 # https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
 # https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
 # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
-c.JupyterHub.cookie_max_age_days = 0.5
+#c.JupyterHub.cookie_max_age_days = 0.5
+
+# DEBUG: 60s cookie_max_age_days, 10s HubAuth.cache_max_age 10s
+c.JupyterHub.cookie_max_age_days = 60 / 86400
+c.BricsSlurmSpawner.args= ['--HubAuth.cache_max_age=10']

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -318,12 +318,12 @@ c.Authenticator.allowed_users = {DUMMY_USERNAME}
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
 
 # Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
-# cookie itself
+# cookie itself, see:
 # https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
 # https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
 # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
-#c.JupyterHub.cookie_max_age_days = 0.5
-
-# DEBUG: 300s cookie_max_age_days, 10s HubAuth.cache_max_age 10s
-c.JupyterHub.cookie_max_age_days = 300 / 86400
-c.BricsSlurmSpawner.args= ['--HubAuth.cache_max_age=10']
+# This value controls the expiry of the signed value of the Hub login cookie (jupyterhub-hub-login)
+# and internal OAuth token cookie for single-user server (jupyterhub-user-username), see:
+# https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
+# https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
+c.JupyterHub.cookie_max_age_days = 0.5

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -324,3 +324,14 @@ c.Authenticator.allowed_users = {DUMMY_USERNAME}
 # the token projects claim will be authenticated. Authenticated users can only spawn to projects
 # associated with this platform name.
 c.BricsAuthenticator.brics_platform = "brics.aip1.notebooks.shared"
+
+# Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
+# cookie itself, see:
+# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
+# https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
+# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
+# This value controls the expiry of the signed value of the Hub login cookie (jupyterhub-hub-login)
+# and internal OAuth token cookie for single-user server (jupyterhub-user-username), see:
+# https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
+# https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
+c.JupyterHub.cookie_max_age_days = 0.5

--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -221,3 +221,14 @@ c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
 
 # Set leeway (in seconds) for validating time-based claims in the JWT.
 c.BricsAuthenticator.jwt_leeway = 5
+
+# Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
+# cookie itself, see:
+# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
+# https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
+# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
+# This value controls the expiry of the signed value of the Hub login cookie (jupyterhub-hub-login)
+# and internal OAuth token cookie for single-user server (jupyterhub-user-username), see:
+# https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
+# https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
+c.JupyterHub.cookie_max_age_days = 0.5

--- a/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -223,12 +223,12 @@ c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
 c.BricsAuthenticator.jwt_leeway = 5
 
 # Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
-# cookie itself
+# cookie itself, see:
 # https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
 # https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
 # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
-#c.JupyterHub.cookie_max_age_days = 0.5
-
-# DEBUG: 300s cookie_max_age_days, 10s HubAuth.cache_max_age 10s
-c.JupyterHub.cookie_max_age_days = 300 / 86400
-c.BricsSlurmSpawner.args= ['--HubAuth.cache_max_age=10']
+# This value controls the expiry of the signed value of the Hub login cookie (jupyterhub-hub-login)
+# and internal OAuth token cookie for single-user server (jupyterhub-user-username), see:
+# https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
+# https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
+c.JupyterHub.cookie_max_age_days = 0.5

--- a/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -221,3 +221,14 @@ c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
 
 # Set leeway (in seconds) for validating time-based claims in the JWT.
 c.BricsAuthenticator.jwt_leeway = 5
+
+# Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
+# cookie itself
+# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
+# https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
+# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
+#c.JupyterHub.cookie_max_age_days = 0.5
+
+# DEBUG: 300s cookie_max_age_days, 10s HubAuth.cache_max_age 10s
+c.JupyterHub.cookie_max_age_days = 300 / 86400
+c.BricsSlurmSpawner.args= ['--HubAuth.cache_max_age=10']

--- a/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -229,3 +229,14 @@ c.BricsAuthenticator.jwt_audience = "zenith-jupyter"
 
 # Set leeway (in seconds) for validating time-based claims in the JWT.
 c.BricsAuthenticator.jwt_leeway = 5
+
+# Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the
+# cookie itself, see:
+# https://github.com/jupyterhub/jupyterhub/blob/01a43f41f8b1554f2de659104284f6345d76636d/jupyterhub/handlers/base.py#L471
+# https://github.com/tornadoweb/tornado/blob/aace116c3f195e127c63b00fd5afadf1587c99d0/tornado/web.py#L862
+# https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie
+# This value controls the expiry of the signed value of the Hub login cookie (jupyterhub-hub-login)
+# and internal OAuth token cookie for single-user server (jupyterhub-user-username), see:
+# https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
+# https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
+c.JupyterHub.cookie_max_age_days = 0.5


### PR DESCRIPTION
* Set `c.JupyterHub.cookie_max_age_days = 0.5` for prod and all dev environments
* This expires the signed value of the Hub login cookie (jupyterhub-hub-login) and the internal OAuth token cookie for single-user server (jupyterhub-user-username) after 12h
* 12h expiry aligns with lifetime of the OAuth2 Proxy session storage cookie used with Zenith server