### PR TITLE
Increase spawner poll intervals to reduce Slurm RPCs

### DIFF
--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -168,6 +168,14 @@ c.Spawner.notebook_dir = '~/'
 # Allow up to 7 mins (420s) for user session to queue and start
 c.Spawner.start_timeout = 420
 
+# Set poll interval (for running Jupyter servers) to 60s to reduce Slurm RPCs
+# (the default is 30s)
+c.BricsSlurmSpawner.poll_interval = 60
+
+# Set poll interval (during Jupyter server startup) to 15s to reduce Slurm RPCs
+# (the default is 0.5s)
+c.BricsSlurmSpawner.startup_poll_interval = 15
+
 def get_ssh_key_file() -> Path:
     """
     Return a path to an SSH key under JUPYTERHUB_SRV_DIR

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -171,6 +171,14 @@ c.Spawner.notebook_dir = '~/'
 # Allow up to 7 mins (420s) for user session to queue and start
 c.Spawner.start_timeout = 420
 
+# Set poll interval (for running Jupyter servers) to 60s to reduce Slurm RPCs
+# (the default is 30s)
+c.BricsSlurmSpawner.poll_interval = 60
+
+# Set poll interval (during Jupyter server startup) to 15s to reduce Slurm RPCs
+# (the default is 0.5s)
+c.BricsSlurmSpawner.startup_poll_interval = 15
+
 def get_ssh_key_file() -> Path:
     """
     Return a path to an SSH key under JUPYTERHUB_SRV_DIR

--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -78,6 +78,14 @@ c.Spawner.notebook_dir = '~/'
 # Allow up to 7 mins (420s) for user session to queue and start
 c.Spawner.start_timeout = 420
 
+# Set poll interval (for running Jupyter servers) to 60s to reduce Slurm RPCs
+# (the default is 30s)
+c.BricsSlurmSpawner.poll_interval = 60
+
+# Set poll interval (during Jupyter server startup) to 15s to reduce Slurm RPCs
+# (the default is 0.5s)
+c.BricsSlurmSpawner.startup_poll_interval = 15
+
 def get_ssh_key_file() -> Path:
     """
     Return a path to an SSH key under JUPYTERHUB_SRV_DIR

--- a/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth_zenithclient/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -78,6 +78,14 @@ c.Spawner.notebook_dir = '~/'
 # Allow up to 7 mins (420s) for user session to queue and start
 c.Spawner.start_timeout = 420
 
+# Set poll interval (for running Jupyter servers) to 60s to reduce Slurm RPCs
+# (the default is 30s)
+c.BricsSlurmSpawner.poll_interval = 60
+
+# Set poll interval (during Jupyter server startup) to 15s to reduce Slurm RPCs
+# (the default is 0.5s)
+c.BricsSlurmSpawner.startup_poll_interval = 15
+
 def get_ssh_key_file() -> Path:
     """
     Return a path to an SSH key under JUPYTERHUB_SRV_DIR

--- a/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -81,6 +81,14 @@ c.Spawner.notebook_dir = '~/'
 # Allow up to 7 mins (420s) for user session to queue and start
 c.Spawner.start_timeout = 420
 
+# Set poll interval (for running Jupyter servers) to 60s to reduce Slurm RPCs
+# (the default is 30s)
+c.BricsSlurmSpawner.poll_interval = 60
+
+# Set poll interval (during Jupyter server startup) to 15s to reduce Slurm RPCs
+# (the default is 0.5s)
+c.BricsSlurmSpawner.startup_poll_interval = 15
+
 def get_ssh_key_file() -> Path:
     """
     Return a path to an SSH key under JUPYTERHUB_SRV_DIR


### PR DESCRIPTION
In order to reduce the number of `slurmctld` RPCs due to polling with `squeue` via `BricsSlurmSpawner`: 

* Increase the poll interval for jobs not started (pending) to 15s from the default 0.5s
* Increase the poll interval for jobs that have started (running) to 60s from the default 30s