### PR TITLE
Add announcement hooks to JupyterHub

### DIFF
--- a/volumes/dev/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -262,3 +262,6 @@ c.BricsAuthenticator.invalid_jwt_logout = True
 # https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
 # https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
 c.JupyterHub.cookie_max_age_days = 0.5
+
+# Paths to search for jinja templates, before using the default templates.
+c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]

--- a/volumes/dev/jupyterhub_root/etc/jupyterhub/templates/spawn.html
+++ b/volumes/dev/jupyterhub_root/etc/jupyterhub/templates/spawn.html
@@ -1,0 +1,2 @@
+{# extends "templates/spawn.html" %} {% set announcement = '<p>Upcoming JupyterHub maintenance: YYYY-MM-DD HH:00-HH:00 UTC.</p><p>See <a href="https://docs.isambard.ac.uk/service-status/planned_maintenance/">Planned Maintenance</a> for details.</p>' #}
+{% extends "templates/spawn.html" %} {% set announcement = "" %}

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -343,3 +343,6 @@ c.Authenticator.allowed_users = {DUMMY_USERNAME}
 # https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
 # https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
 c.JupyterHub.cookie_max_age_days = 0.5
+
+# Paths to search for jinja templates, before using the default templates.
+c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/templates/spawn.html
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/templates/spawn.html
@@ -1,0 +1,2 @@
+{# extends "templates/spawn.html" %} {% set announcement = '<p>Upcoming JupyterHub maintenance: YYYY-MM-DD HH:00-HH:00 UTC.</p><p>See <a href="https://docs.isambard.ac.uk/service-status/planned_maintenance/">Planned Maintenance</a> for details.</p>' #}
+{% extends "templates/spawn.html" %} {% set announcement = "" %}

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -346,3 +346,6 @@ c.Authenticator.allowed_users = {DUMMY_USERNAME}
 # https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
 # https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
 c.JupyterHub.cookie_max_age_days = 0.5
+
+# Paths to search for jinja templates, before using the default templates.
+c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/templates/spawn.html
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/templates/spawn.html
@@ -1,0 +1,2 @@
+{# extends "templates/spawn.html" %} {% set announcement = '<p>Upcoming JupyterHub maintenance: YYYY-MM-DD HH:00-HH:00 UTC.</p><p>See <a href="https://docs.isambard.ac.uk/service-status/planned_maintenance/">Planned Maintenance</a> for details.</p>' #}
+{% extends "templates/spawn.html" %} {% set announcement = "" %}

--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -262,3 +262,6 @@ c.BricsAuthenticator.invalid_jwt_logout = True
 # https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
 # https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
 c.JupyterHub.cookie_max_age_days = 0.5
+
+# Paths to search for jinja templates, before using the default templates.
+c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]

--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/templates/spawn.html
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/templates/spawn.html
@@ -1,0 +1,2 @@
+{# extends "templates/spawn.html" %} {% set announcement = '<p>Upcoming JupyterHub maintenance: YYYY-MM-DD HH:00-HH:00 UTC.</p><p>See <a href="https://docs.isambard.ac.uk/service-status/planned_maintenance/">Planned Maintenance</a> for details.</p>' #}
+{% extends "templates/spawn.html" %} {% set announcement = "" %}

--- a/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -265,3 +265,6 @@ c.BricsAuthenticator.invalid_jwt_logout = True
 # https://jupyterhub.readthedocs.io/en/latest/tutorial/getting-started/security-basics.html#cookies-used-by-jupyterhub-authentication
 # https://jupyterhub.readthedocs.io/en/latest/explanation/oauth.html#token-caches-and-expiry
 c.JupyterHub.cookie_max_age_days = 0.5
+
+# Paths to search for jinja templates, before using the default templates.
+c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]

--- a/volumes/prod/jupyterhub_root/etc/jupyterhub/templates/spawn.html
+++ b/volumes/prod/jupyterhub_root/etc/jupyterhub/templates/spawn.html
@@ -1,0 +1,2 @@
+{# extends "templates/spawn.html" %} {% set announcement = '<p>Upcoming JupyterHub maintenance: YYYY-MM-DD HH:00-HH:00 UTC.</p><p>See <a href="https://docs.isambard.ac.uk/service-status/planned_maintenance/">Planned Maintenance</a> for details.</p>' #}
+{% extends "templates/spawn.html" %} {% set announcement = "" %}


### PR DESCRIPTION
With this deployed, one can run (on the server where Podman is running):
```shell-session
podman unshare
vim $(podman volume mount jupyterhub_root_prod)/etc/jupyterhub/templates/spawn.html
podman volume unmount jupyterhub_root_prod
exit
```

Changes to this file will be shown live on the spawner page.

These instructions should be added to the Admin Guide once deployed.

Fixes isambard-sc/jupyter-platform#125