### PR TITLE
Add a brics-admin role based on brics-admins group

### DIFF
--- a/volumes/dev/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -265,3 +265,22 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 # Paths to search for jinja templates, before using the default templates.
 c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]
+
+c.Authenticator.manage_groups = True
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "brics-admin",
+        "description": "BriCS admins",
+        "scopes": [
+            "admin-ui",
+            "read:servers", "delete:servers",
+            "read:groups", "list:groups",
+            "read:roles",
+            "read:users", "list:users",
+            "read:services", "list:services",
+            "access:services",
+        ],
+        "groups": ["brics-admins"],
+    },
+]

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -346,3 +346,22 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 # Paths to search for jinja templates, before using the default templates.
 c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]
+
+c.Authenticator.manage_groups = True
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "brics-admin",
+        "description": "BriCS admins",
+        "scopes": [
+            "admin-ui",
+            "read:servers", "delete:servers",
+            "read:groups", "list:groups",
+            "read:roles",
+            "read:users", "list:users",
+            "read:services", "list:services",
+            "access:services",
+        ],
+        "groups": ["brics-admins"],
+    },
+]

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -349,3 +349,22 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 # Paths to search for jinja templates, before using the default templates.
 c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]
+
+c.Authenticator.manage_groups = True
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "brics-admin",
+        "description": "BriCS admins",
+        "scopes": [
+            "admin-ui",
+            "read:servers", "delete:servers",
+            "read:groups", "list:groups",
+            "read:roles",
+            "read:users", "list:users",
+            "read:services", "list:services",
+            "access:services",
+        ],
+        "groups": ["brics-admins"],
+    },
+]

--- a/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_realauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -265,3 +265,22 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 # Paths to search for jinja templates, before using the default templates.
 c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]
+
+c.Authenticator.manage_groups = True
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "brics-admin",
+        "description": "BriCS admins",
+        "scopes": [
+            "admin-ui",
+            "read:servers", "delete:servers",
+            "read:groups", "list:groups",
+            "read:roles",
+            "read:users", "list:users",
+            "read:services", "list:services",
+            "access:services",
+        ],
+        "groups": ["brics-admins"],
+    },
+]

--- a/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/prod/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -268,3 +268,22 @@ c.JupyterHub.cookie_max_age_days = 0.5
 
 # Paths to search for jinja templates, before using the default templates.
 c.JupyterHub.template_paths = [Path(__file__).parent.joinpath("templates").resolve()]
+
+c.Authenticator.manage_groups = True
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "brics-admin",
+        "description": "BriCS admins",
+        "scopes": [
+            "admin-ui",
+            "read:servers", "delete:servers",
+            "read:groups", "list:groups",
+            "read:roles",
+            "read:users", "list:users",
+            "read:services", "list:services",
+            "access:services",
+        ],
+        "groups": ["brics-admins"],
+    },
+]


### PR DESCRIPTION
With this change, anyone in the `brics-admins` group will be assigned the `brics-admin` role which gives access to most useful admin features, including listing and shutting down servers.

See isambard-sc/bricsauthenticator#19