### PR TITLE
Add support for admins to the dummy authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ JupyterHub and Slurm containers in a Podman pod interacting over SSH with mocked
 In this environment, JupyterHub is configured to use `DummyBricsAuthenticator` (defined in [the JupyterHub configuration file](./volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py)) which mocks the behaviour of `BricsAuthenticator` from [bricsauthenticator][bricsauthenticator-github], authenticating against any users defined in `devUsers` or `devAdmins`.
 The username provided in the login form is matched against the full name from `devAdmins` or agaisnt the `<USER>` part of `<USER>.<PROJECT>` in `devUsers`.
 For `devUsers`, the user is authenticated with a projects claim containing the list of all projects associated with that user (`<PROJECT>` for all usernames of form `<USER>.<PROJECT>` where `<USER>` is the authenticated user).
-For `devAdmins`, the user is palced in the `brics-admins` group.
+For `devAdmins`, the user is placed in the `brics-admins` group.
 The password entered at the login form must match the value of `dummyAuthPassword` in the deploy `ConfigMap`.
 
 This environment is intended to be used for testing non-authentication components, where user HTTP requests to the JupyterHub server do not include a valid JWT to authenticate to JupyterHub.

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ JupyterHub and Slurm containers in a Podman pod interacting over SSH with mocked
 * Deployment scripts: [scripts/dev_dummyauth](./scripts/dev_dummyauth)
 * Example deploy `ConfigMap`: [examples/dev_dummyauth/deploy-configmap.yaml](./examples/dev_dummyauth/deploy-configmap.yaml)
 
-In this environment, JupyterHub is configured to use `DummyBricsAuthenticator` (defined in [the JupyterHub configuration file](./volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py)) which mocks the behaviour of `BricsAuthenticator` from [bricsauthenticator][bricsauthenticator-github], authenticating the first user from the value of `devUsers` in the deploy `ConfigMap` (`<USER>` part of `<USER>.<PROJECT>`).
-The user is authenticated with a projects claim containing the list of all projects associated with that user in the value of `devUsers` (`<PROJECT>` for all usernames of form `<USER>.<PROJECT>` where `<USER>` is the authenticated user).
-
-`DummyBricsAuthenticator` overrides JupyterHub's `SharedPasswordAuthenticator.authenticate()` method such that the username from the login form is discarded and the user authenticated is based on the value of `devUsers` in the deploy `ConfigMap`.
-However, the password entered at the login form must match the value of `dummyAuthPassword` in the deploy `ConfigMap`.
+In this environment, JupyterHub is configured to use `DummyBricsAuthenticator` (defined in [the JupyterHub configuration file](./volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py)) which mocks the behaviour of `BricsAuthenticator` from [bricsauthenticator][bricsauthenticator-github], authenticating against any users defined in `devUsers` or `devAdmins`.
+The username provided in the login form is matched against the full name from `devAdmins` or agaisnt the `<USER>` part of `<USER>.<PROJECT>` in `devUsers`.
+For `devUsers`, the user is authenticated with a projects claim containing the list of all projects associated with that user (`<PROJECT>` for all usernames of form `<USER>.<PROJECT>` where `<USER>` is the authenticated user).
+For `devAdmins`, the user is palced in the `brics-admins` group.
+The password entered at the login form must match the value of `dummyAuthPassword` in the deploy `ConfigMap`.
 
 This environment is intended to be used for testing non-authentication components, where user HTTP requests to the JupyterHub server do not include a valid JWT to authenticate to JupyterHub.
 
@@ -125,12 +125,12 @@ JupyterHub in a Podman pod interacting with an external Slurm instance over SSH 
 * Deployment scripts: [scripts/dev_dummyauth_extslurm](./scripts/dev_dummyauth_extslurm)
 * Example deploy `ConfigMap`: [examples/dev_dummyauth_extslurm/deploy-configmap.yaml](./examples/dev_dummyauth_extslurm/deploy-configmap.yaml)
 
-In this environment, JupyterHub is configured to use `DummyBricsAuthenticator` (defined in [the JupyterHub configuration file](./volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py)) which mocks the behaviour of `BricsAuthenticator` from [bricsauthenticator][bricsauthenticator-github], authenticating the first user from the value of `devUsers` in the deploy `ConfigMap` (`<USER>` part of `<USER>.<PROJECT>`).
+In this environment, JupyterHub is configured to use `DummyBricsAuthenticator` (defined in [the JupyterHub configuration file](./volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py)) which mocks the behaviour of `BricsAuthenticator` from [bricsauthenticator][bricsauthenticator-github], authenticating against any users defined in `devUsers` or `devAdmins`.
 
 In order for spawning to work in the external Slurm instance, the `jupyterspawner` service user on the host `sshHostname` should be able to switch users using `sudo -u <USER>.<PROJECT>` and run [`slurmspawner_wrappers`](slurmspawner_wrappers-github) scripts on behalf of the user to run jobs.
 See [`jupyterhub_config.py`](./volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py) for details of the commands run on the SSH server, and [`jupyterspawner_sudoers`](./brics_slurm/jupyterspawner_sudoers) for an example `sudoers` configuration fragment that grants these permissions in the [`brics_slurm` container](./brics_slurm/Containerfile).
 
-As in [`dev_dummyauth`](#dev_dummyauth), `DummyBricsAuthenticator` overrides JupyterHub's `SharedPasswordAuthenticator.authenticate()` and a password (`dummyAuthPassword`) must be provided to access JupyterHub as the user specified in `devUsers`
+As in [`dev_dummyauth`](#dev_dummyauth), `DummyBricsAuthenticator` overrides JupyterHub's `SharedPasswordAuthenticator.authenticate()` and a password (`dummyAuthPassword`) must be provided to access JupyterHub as the user specified in `devUsers` or `devAdmins`.
 
 This environment is intended to be used for testing non-authentication components and interaction with an external Slurm instance.
 
@@ -212,7 +212,8 @@ Deploy `ConfigMap` configuration keys
 | --- | ---------- | ----------- |
 | `logLevel` | All | Set the log level for JupyterHub using values from [Python `logging` module][logging-levels-python-docs] (e.g. "DEBUG", "INFO") |
 | `baseUrl` | All | URL base path added to the beginning of all Jupyter URL paths |
-| `devUsers` | `dev_dummyauth`, `dev_dummyauth_extslurm`, `dev_realauth`, `dev_realauth_zenithclient` | Space-separated list of usernames of the form `<USER>.<PROJECT>`, where `<USER>` corresponds to the `short_name` authentication token claim and `<PROJECT>` is a key from the `projects` authentication token claim. |
+| `devUsers` | `dev_dummyauth`, `dev_dummyauth_extslurm`, `dev_realauth`, `dev` | Space-separated list of usernames of the form `<USER>.<PROJECT>`, where `<USER>` corresponds to the `short_name` authentication token claim and `<PROJECT>` is a key from the `projects` authentication token claim. |
+| `devAdmins` | `dev_dummyauth`, `dev_dummyauth_extslurm`, `dev_realauth`, `dev` | Space-separated list of usernames. authenticating as one of these will put you in the `brics-admins` group. |
 | `dummyAuthPassword` | `dev_dummyauth`, `dev_dummyauth_extslurm` | Password to be entered at the login form to access JupyterHub via `DummyBricsAuthenticator` see below for [advice on setting `dummyAuthPassword`](#setting-dummyauthpassword) |
 | `sshHostname` | All |  Host name or IP address that JupyterHub should connect to over SSH to run Slurm commands via [slurmspawner_wrappers](slurmspawner_wrappers-github) |
 | `slurmSpawnerWrappersBin` | All | Path to directory containing the `slurmspawner_{sbatch,scancel,squeue}` scripts on the SSH server (typically installed within a Python venv) |

--- a/config/dev_dummyauth/pod.yaml
+++ b/config/dev_dummyauth/pod.yaml
@@ -25,6 +25,12 @@ spec:
               name: deploy-config
               key: devUsers
               optional: false
+        - name: DEPLOY_CONFIG_DEV_ADMINS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devAdmins
+              optional: false
         - name: DEPLOY_CONFIG_DUMMYAUTH_PASSWORD
           valueFrom:
             configMapKeyRef:

--- a/config/dev_dummyauth_extslurm/pod.yaml
+++ b/config/dev_dummyauth_extslurm/pod.yaml
@@ -25,6 +25,12 @@ spec:
               name: deploy-config
               key: devUsers
               optional: false
+        - name: DEPLOY_CONFIG_DEV_ADMINS
+          valueFrom:
+            configMapKeyRef:
+              name: deploy-config
+              key: devAdmins
+              optional: false
         - name: DEPLOY_CONFIG_DUMMYAUTH_PASSWORD
           valueFrom:
             configMapKeyRef:

--- a/examples/dev_dummyauth/deploy-configmap.yaml
+++ b/examples/dev_dummyauth/deploy-configmap.yaml
@@ -15,6 +15,10 @@ data:
   # Change this to deployment specific value
   devUsers: "testuser.project1 testuser.project2 otheruser.project1"
 
+  # Space-separated list of admin usernames used in dev environment
+  # Change this to deployment specific value
+  devAdmins: "test1-admin test2-admin"
+
   # Password to be entered at the login form to access JupyterHub
   # Change this to deployment specific value
   dummyAuthPassword: "MyVerySecurePassword"

--- a/examples/dev_dummyauth_extslurm/deploy-configmap.yaml
+++ b/examples/dev_dummyauth_extslurm/deploy-configmap.yaml
@@ -15,6 +15,10 @@ data:
   # Change this to deployment specific value
   devUsers: "testuser.project1 testuser.project2 otheruser.project1"
 
+  # Space-separated list of admin usernames used in dev environment
+  # Change this to deployment specific value
+  devAdmins: "test1-admin test2-admin"
+
   # Password to be entered at the login form to access JupyterHub
   # Change this to deployment specific value
   dummyAuthPassword: "MyVerySecurePassword"

--- a/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -37,13 +37,11 @@ c.JupyterHub.hub_bind_url = "http://127.0.0.1:8081"
 # * https://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html#authentication-state
 # * https://github.com/isambard-sc/bricsauthenticator/blob/main/src/bricsauthenticator/bricsauthenticator.py
 
-# DUMMY_USERNAME is a fixed username which looks like a decoded short_name claim
-# used to identify the user to be authenticated to JupyterHub, mocking the
-# behaviour of BricsAuthenticator without receiving a JWT. This is obtained
-# from the environment variable DEPLOY_CONFIG_DEV_USERS which should contain
-# a space-separated list of usernames of the form `<USER>.<PROJECT>`. The
-# DUMMY_USERNAME is the `<USER>` part of the first `<USER>.<PROJECT>` name in
-# in the list.
+# short_name_claims is a list of fixed usernames which looks like a decoded
+# short_name claim used to identify the user to be authenticated to JupyterHub,
+# mocking the behaviour of BricsAuthenticator without receiving a JWT. This is
+# obtained from the environment variable DEPLOY_CONFIG_DEV_USERS which should
+# contain a space-separated list of usernames of the form `<USER>.<PROJECT>`.
 def get_short_name_claim_list() -> list[str]:
     """
     Return a list of strings that look like decoded short_name claims
@@ -62,7 +60,6 @@ def get_short_name_claim_list() -> list[str]:
     return list(OrderedDict.fromkeys([unix_username.split(".")[0] for unix_username in unix_usernames.split()]))
 
 short_name_claims = get_short_name_claim_list()
-DUMMY_USERNAME = short_name_claims[0]
 
 # DUMMY_AUTH_STATE is a fixed dictionary which mocks the auth_state passed to
 # BricsSlurmSpawner by BricsAuthenticator, used to mock the behaviour of
@@ -105,7 +102,14 @@ def get_auth_state(username: str, portal_shortname: str = "brics") -> dict[str, 
 
     return auth_state
 
-DUMMY_AUTH_STATE = get_auth_state(DUMMY_USERNAME)
+def get_groups(username: str) -> list[str]:
+    """
+    Return the groups for a given username
+    """
+    admin_unix_usernames = get_env_var_value("DEPLOY_CONFIG_DEV_ADMINS")
+    if username in admin_unix_usernames:
+        return ["brics-admins"]
+    return []
 
 class DummyBricsAuthenticator(SharedPasswordAuthenticator):
     """
@@ -121,10 +125,13 @@ class DummyBricsAuthenticator(SharedPasswordAuthenticator):
     """
     async def authenticate(self, handler, data):
        # Delegate password authentication to parent class method.
-       # If successful, authenticate user using fixed dummy username and
-       # auth_state.
+       # If successful, authenticate user using username and extracted auth_state.
        if await super().authenticate(handler, data) is not None:
-           return {"name": DUMMY_USERNAME, "auth_state": DUMMY_AUTH_STATE, "admin": False}
+           return {
+               "name": data["username"],
+               "auth_state": get_auth_state(data["username"]),
+               "groups": get_groups(data["username"])
+           }
        return None
 
 # Use SharedPasswordAuthenticator extended to provide mock auth_state to
@@ -330,7 +337,7 @@ c.Authenticator.user_password = get_env_var_value("DEPLOY_CONFIG_DUMMYAUTH_PASSW
 
 # Add the default fixed username used by DummyBricsAuthenticator to list of
 # allowed users
-c.Authenticator.allowed_users = {DUMMY_USERNAME}
+c.Authenticator.allowed_users = short_name_claims + get_env_var_value("DEPLOY_CONFIG_DEV_ADMINS").split()
 
 
 # Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the

--- a/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
+++ b/volumes/dev_dummyauth_extslurm/jupyterhub_root/etc/jupyterhub/jupyterhub_config.py
@@ -38,13 +38,11 @@ c.JupyterHub.hub_bind_url = "http://:8081"
 # * https://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html#authentication-state
 # * https://github.com/isambard-sc/bricsauthenticator/blob/main/src/bricsauthenticator/bricsauthenticator.py
 
-# DUMMY_USERNAME is a fixed username which looks like a decoded short_name claim
-# used to identify the user to be authenticated to JupyterHub, mocking the
-# behaviour of BricsAuthenticator without receiving a JWT. This is obtained
-# from the environment variable DEPLOY_CONFIG_DEV_USERS which should contain
-# a space-separated list of usernames of the form `<USER>.<PROJECT>`. The
-# DUMMY_USERNAME is the `<USER>` part of the first `<USER>.<PROJECT>` name in
-# in the list.
+# short_name_claims is a list of fixed usernames which looks like a decoded
+# short_name claim used to identify the user to be authenticated to JupyterHub,
+# mocking the behaviour of BricsAuthenticator without receiving a JWT. This is
+# obtained from the environment variable DEPLOY_CONFIG_DEV_USERS which should
+# contain a space-separated list of usernames of the form `<USER>.<PROJECT>`.
 def get_short_name_claim_list() -> list[str]:
     """
     Return a list of strings that look like decoded short_name claims
@@ -63,7 +61,6 @@ def get_short_name_claim_list() -> list[str]:
     return list(OrderedDict.fromkeys([unix_username.split(".")[0] for unix_username in unix_usernames.split()]))
 
 short_name_claims = get_short_name_claim_list()
-DUMMY_USERNAME = short_name_claims[0]
 
 # DUMMY_AUTH_STATE is a fixed dictionary which mocks the auth_state passed to
 # BricsSlurmSpawner by BricsAuthenticator, used to mock the behaviour of
@@ -106,7 +103,14 @@ def get_auth_state(username: str, portal_shortname: str = "brics") -> dict[str, 
 
     return auth_state
 
-DUMMY_AUTH_STATE = get_auth_state(DUMMY_USERNAME)
+def get_groups(username: str) -> list[str]:
+    """
+    Return the groups for a given username
+    """
+    admin_unix_usernames = get_env_var_value("DEPLOY_CONFIG_DEV_ADMINS")
+    if username in admin_unix_usernames:
+        return ["brics-admins"]
+    return []
 
 class DummyBricsAuthenticator(SharedPasswordAuthenticator):
     """
@@ -122,10 +126,13 @@ class DummyBricsAuthenticator(SharedPasswordAuthenticator):
     """
     async def authenticate(self, handler, data):
        # Delegate password authentication to parent class method.
-       # If successful, authenticate user using fixed dummy username and
-       # auth_state.
+       # If successful, authenticate user using username and extracted auth_state.
        if await super().authenticate(handler, data) is not None:
-           return {"name": DUMMY_USERNAME, "auth_state": DUMMY_AUTH_STATE, "admin": False}
+           return {
+               "name": data["username"],
+               "auth_state": get_auth_state(data["username"]),
+               "groups": get_groups(data["username"])
+           }
        return None
 
 # Use SharedPasswordAuthenticator extended to provide mock auth_state to
@@ -333,7 +340,7 @@ c.Authenticator.user_password = get_env_var_value("DEPLOY_CONFIG_DUMMYAUTH_PASSW
 
 # Add the default fixed username used by DummyBricsAuthenticator to list of
 # allowed users
-c.Authenticator.allowed_users = {DUMMY_USERNAME}
+c.Authenticator.allowed_users = short_name_claims + get_env_var_value("DEPLOY_CONFIG_DEV_ADMINS").split()
 
 
 # Set 12 h cookie_max_age_days value which expires the signed value of the cookie rather than the


### PR DESCRIPTION
This allows for a `devAdmins` config map field to define admin users.

This also allows the actual typed username to be used, rather than always using the first one in the `devUsers` list.