### PR TITLE
Set default values for Nadir client in image

### DIFF
--- a/config/dev/pod.yaml
+++ b/config/dev/pod.yaml
@@ -189,20 +189,12 @@ spec:
     - name: nadir-client
       image: localhost/nadir-client:dev-latest
       env:
-        - name: NADIR_SERVER_ADDRESS_PATH
-          value: /etc/nadir/server_address
-        - name: NADIR_SERVER_SSH_PORT
-          value: 22
-        - name: NADIR_CLIENT_SSH_IDENTITY_PATH
-          value: /etc/nadir/ssh_key
         - name: NADIR_CLIENT_FORWARD_TO_HOST
           value: 127.0.0.1
         - name: NADIR_CLIENT_FORWARD_TO_PORT
           value: 8000
-        - name: NADIR_CLIENT_REMOTE_PORT
-          value: 8000
       volumeMounts:
-        # Configuration file for Nadir client
+        # Nadir SSH server address
         - name: nadir_config_vol
           mountPath: /etc/nadir/server_address
           readOnly: true
@@ -213,12 +205,6 @@ spec:
           mountPath: /etc/nadir/ssh_key
           readOnly: true
           subPath: ssh_key
-
-        # SSH public key for Nadir client from Secret
-        - name: nadir_key_vol
-          mountPath: /etc/nadir/ssh_key.pub
-          readOnly: true
-          subPath: ssh_key.pub
 
   volumes:
     - name: jupyterhub_root_vol

--- a/config/prod/pod.yaml
+++ b/config/prod/pod.yaml
@@ -121,20 +121,12 @@ spec:
     - name: nadir-client
       image: localhost/nadir-client:latest
       env:
-        - name: NADIR_SERVER_ADDRESS_PATH
-          value: /etc/nadir/server_address
-        - name: NADIR_SERVER_SSH_PORT
-          value: 22
-        - name: NADIR_CLIENT_SSH_IDENTITY_PATH
-          value: /etc/nadir/ssh_key
         - name: NADIR_CLIENT_FORWARD_TO_HOST
           value: 127.0.0.1
         - name: NADIR_CLIENT_FORWARD_TO_PORT
           value: 8000
-        - name: NADIR_CLIENT_REMOTE_PORT
-          value: 8000
       volumeMounts:
-        # Configuration file for Nadir client
+        # Nadir SSH server address
         - name: nadir_config_vol
           mountPath: /etc/nadir/server_address
           readOnly: true
@@ -145,12 +137,6 @@ spec:
           mountPath: /etc/nadir/ssh_key
           readOnly: true
           subPath: ssh_key
-
-        # SSH public key for Nadir client from Secret
-        - name: nadir_key_vol
-          mountPath: /etc/nadir/ssh_key.pub
-          readOnly: true
-          subPath: ssh_key.pub
 
   volumes:
     - name: jupyterhub_root_vol

--- a/nadir-client/Containerfile
+++ b/nadir-client/Containerfile
@@ -1,5 +1,19 @@
 FROM ghcr.io/linuxcontainers/alpine:latest as stage-base
 
+# File containing the name host name of the Nadir SSH server
+ENV NADIR_SERVER_ADDRESS_PATH=/etc/nadir/server_address
+# The port of the Nadir SSH server
+ENV NADIR_SERVER_SSH_PORT=22
+# The port to open at the Nadir SSH server
+ENV NADIR_CLIENT_REMOTE_PORT=8000
+# The path the the SSH identity file
+ENV NADIR_CLIENT_SSH_IDENTITY_PATH=/etc/nadir/ssh_key
+
+# The client-side host to forward traffic to
+#ENV NADIR_CLIENT_FORWARD_TO_HOST
+# The client-side port
+#ENV NADIR_CLIENT_FORWARD_TO_PORT
+
 RUN apk add openssh
 CMD ssh "nadir@$(cat ${NADIR_SERVER_ADDRESS_PATH})" -p "${NADIR_SERVER_SSH_PORT}" -R "*:${NADIR_CLIENT_REMOTE_PORT}:${NADIR_CLIENT_FORWARD_TO_HOST}:${NADIR_CLIENT_FORWARD_TO_PORT}" -i "${NADIR_CLIENT_SSH_IDENTITY_PATH}" -v -o ExitOnForwardFailure=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o RequestTTY=no -o SessionType=none -o ServerAliveCountMax=21 -o ServerAliveInterval=15
 


### PR DESCRIPTION
Simplify the deployment of Nadir by setting defaults for most of the variables. The only things that need to be set are then `NADIR_CLIENT_FORWARD_TO_HOST` and `NADIR_CLIENT_FORWARD_TO_PORT`.